### PR TITLE
Fix FTBFS on OpenPOWER systems

### DIFF
--- a/src/inc/hsa.h
+++ b/src/inc/hsa.h
@@ -80,7 +80,7 @@
 // Try to detect CPU endianness
 #if !defined(LITTLEENDIAN_CPU) && !defined(BIGENDIAN_CPU)
 #if defined(__i386__) || defined(__x86_64__) || defined(_M_IX86) || \
-    defined(_M_X64)
+    defined(_M_X64) || defined(__ppc64__)
 #define LITTLEENDIAN_CPU
 #endif
 #endif


### PR DESCRIPTION
This resolves an HCC build failure on OpenPOWER systems.  IBM has stated that all future OpenPOWER development should be little endian, so this change should be safe.