### PR TITLE
Address a gcc 7 format overflow error

### DIFF
--- a/src/core/runtime/hsa.cpp
+++ b/src/core/runtime/hsa.cpp
@@ -377,7 +377,7 @@ static size_t get_extension_table_length(uint16_t extension, uint16_t major, uin
   }
 
   char buff[3];
-  sprintf(buff, "%02u", minor);
+  sprintf(buff, "%02u", minor%100);
   name += std::to_string(major) + "_" + buff + "_pfn_t";
 
   for (size_t i = 0; i < num_tables; i++) {


### PR DESCRIPTION
Although there is a check that `minor` is `<= 99` earlier in the function, the `sprintf` call triggers,

```
error: '%02u' directive writing between 2 and 5 bytes into a region of size 3 [-Werror=format-overflow=]
```

in gcc 7. This change makes the upper bound visible to gcc at the `sprintf` call site.