### PR TITLE
Supports architectures and operating systems that use large page size

### DIFF
--- a/src/core/inc/amd_memory_region.h
+++ b/src/core/inc/amd_memory_region.h
@@ -187,7 +187,7 @@ class MemoryRegion : public core::MemoryRegion {
 
   mutable KernelMutex access_lock_;
 
-  static const size_t kPageSize_ = 4096;
+  static size_t kPageSize_;
 
   // Determine access type allowed to requesting device
   hsa_amd_memory_pool_access_t GetAccessInfo(const core::Agent& agent,

--- a/src/core/runtime/amd_memory_region.cpp
+++ b/src/core/runtime/amd_memory_region.cpp
@@ -50,12 +50,14 @@
 #include "core/inc/amd_gpu_agent.h"
 #include "core/util/utils.h"
 #include "core/inc/exceptions.h"
+#include <unistd.h>
 
 namespace rocr {
 namespace AMD {
 
 // Tracks aggregate size of system memory available on platform
 size_t MemoryRegion::max_sysmem_alloc_size_ = 0;
+size_t MemoryRegion::kPageSize_ = sysconf(_SC_PAGESIZE);
 
 void* MemoryRegion::AllocateKfdMemory(const HsaMemFlags& flag,
                                       HSAuint32 node_id, size_t size) {
@@ -123,7 +125,7 @@ MemoryRegion::MemoryRegion(bool fine_grain, bool kernarg, bool full_profile, cor
 
     virtual_size_ = kGpuVmSize;
   } else if (IsSystem()) {
-    mem_flag_.ui32.PageSize = HSA_PAGE_SIZE_4KB;
+    mem_flag_.ui32.PageSize = MemoryRegion::kPageSize_;
     mem_flag_.ui32.NoSubstitute = 0;
     mem_flag_.ui32.HostAccess = 1;
     mem_flag_.ui32.CachePolicy = HSA_CACHING_CACHED;


### PR DESCRIPTION
This patch will support architectures and operating systems( centos or openEuler on aarch64 ) that use large page size, like 64KB, 2MB PAGE SEZE.

I found a memory allocation error, when rocm-info runs on an operating system with PAGE_SIZE_64KB. The debug information is shown in the figure.
![image](https://user-images.githubusercontent.com/20717885/134758409-67619a97-8d58-4138-b024-2405acde87b9.png)

The function call path that caused the error is as follows:
BindVmFaultHandler->InterruptSignal->LocalSignal->Shared->SharedSignalPool_t::alloc->Runtime::AllocateMemory->MemoryRegion::Allocate->AllocateKfdMemory->hsaKmtAllocMemory->fmm_allocate_host->fmm_allocate_host_gpu->aperture_allocate_area->reserved_aperture_allocate_aligned. After the function aperture_allocate_area is called, mmap will be called immediately and cause an error.

Since kPageSize_ in ROCR is set to 4K, the memory allocated by the function reserved_aperture_allocate_aligned in ROCT-Thunk-Interface is always aligned with 4K. When the kernel page size is other values, the anonymous mmap with MAP_FIXED called later will fail.
