### PR TITLE
The number of records should be in unit of stride for structured buffer

### DIFF
--- a/src/image/image_manager_ai.cpp
+++ b/src/image/image_manager_ai.cpp
@@ -294,7 +294,7 @@ hsa_status_t ImageManagerAi::PopulateImageSrd(Image& image) const {
     word1.f.swizzle_enable = false;
     word1.f.cache_swizzle = false;
 
-    word2.f.num_records = image.desc.width * image_prop.element_size;
+    word2.f.num_records = image.desc.width;
 
     const Swizzle swizzle =
         image_lut_.MapSwizzle(image.desc.format.channel_order);


### PR DESCRIPTION
the 1DB Buffer shoud use
Structured Buffer
Used when: AddTID==0 && Stride!=0 && IdxEn==1
Out of Range if: Index(vgpr) >= NumRecords