### PR TITLE
Improve Endianness check

### DIFF
--- a/src/inc/hsa.h
+++ b/src/inc/hsa.h
@@ -79,7 +79,11 @@
 
 // Try to detect CPU endianness
 #if !defined(LITTLEENDIAN_CPU) && !defined(BIGENDIAN_CPU)
-#if defined(__i386__) || defined(__x86_64__) || defined(_M_IX86) || \
+#if defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
+#define LITTLEENDIAN_CPU
+#elif defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
+#define BIGENDIAN_CPU
+#elif defined(__i386__) || defined(__x86_64__) || defined(_M_IX86) || \
     defined(_M_X64)
 #define LITTLEENDIAN_CPU
 #endif


### PR DESCRIPTION
Summary:
This patch simply updates the `hsa.h` header to use the gcc / clang
`__BYTE_ORDER__` macros where available to more accurately autodetect
endianness for the target.
