### PR TITLE
Add executable symbol info for the wavefront size

### DIFF
--- a/src/inc/hsa.h
+++ b/src/inc/hsa.h
@@ -5642,7 +5642,12 @@ typedef enum {
    * undefined if the symbol is not an indirect function. The type of this
    * attribute is uint32_t.
    */
-  HSA_CODE_SYMBOL_INFO_INDIRECT_FUNCTION_CALL_CONVENTION = 16
+  HSA_CODE_SYMBOL_INFO_INDIRECT_FUNCTION_CALL_CONVENTION = 16,
+  /**
+   * Wavefront size used by the kernel. The value of this attribute is either
+   * 32 or 64. The type of this attribute is uint32_t.
+   */
+  HSA_CODE_SYMBOL_INFO_KERNEL_WAVEFRONT_SIZE = 19
 } hsa_code_symbol_info_t;
 
 /**

--- a/src/loader/executable.hpp
+++ b/src/loader/executable.hpp
@@ -144,6 +144,7 @@ public:
                const bool &_is_dynamic_callstack,
                const uint32_t &_size,
                const uint32_t &_alignment,
+               const uint32_t &_wavefront_size,
                const uint64_t &_address = 0)
     : SymbolImpl(_is_loaded,
                  HSA_SYMBOL_KIND_KERNEL,
@@ -159,7 +160,8 @@ public:
     , private_segment_size(_private_segment_size)
     , is_dynamic_callstack(_is_dynamic_callstack)
     , size(_size)
-    , alignment(_alignment) {}
+    , alignment(_alignment)
+    , wavefront_size(_wavefront_size) {}
 
   ~KernelSymbol() {}
 
@@ -173,6 +175,7 @@ public:
   bool is_dynamic_callstack;
   uint32_t size;
   uint32_t alignment;
+  uint32_t wavefront_size;
   amd_runtime_loader_debug_info_t debug_info;
 
 private:


### PR DESCRIPTION
Summary:
The wavefront size is currently only exposed as an agent level
attribute. This is not correctyl, because while the agent has a default
wave front size that is usually correct, it can easily be overridden via
options like `-mwavefrontsize64` on various ISAs. The wavefrontsize
attribute is actually more of a calling convention that is consistent
within a callgraph. Because the root of each call graph is a kernel in
this architecture, we need to be able to query this on a per-kernel
basis. This information is already avialable in the kernel descriptor
packet, but it wasn't exported.

This patch adds `HSA_CODE_SYMBOL_INFO_KERNEL_WAVEFRONT_SIZE` as a new
option to query on the executable symbol.
