### PR TITLE
Miscellaneous changes to support in-tree builds.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -95,8 +95,14 @@ set ( PACKAGE_VERSION_STRING "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_COMMIT
 ## Find external dependencies.
 find_package(PkgConfig)
 find_package(LibElf REQUIRED)
-find_package(hsakmt 1.0 REQUIRED HINTS ${CMAKE_INSTALL_PREFIX} PATHS /opt/rocm)
 pkg_check_modules(drm REQUIRED IMPORTED_TARGET libdrm)
+
+## Find dependencies that may be built with us or from an installed package.
+if(TARGET hsakmt::hsakmt)
+  message(STATUS "Using build dep on hsakmt")
+else()
+  find_package(hsakmt 1.0 REQUIRED HINTS ${CMAKE_INSTALL_PREFIX} PATHS /opt/rocm)
+endif()
 
 ## Create the rocr target.
 add_library( ${CORE_RUNTIME_TARGET} "" )
@@ -126,6 +132,19 @@ target_include_directories( ${CORE_RUNTIME_TARGET}
   ${CMAKE_CURRENT_BINARY_DIR}/core/runtime/trap_handler
   ${CMAKE_CURRENT_BINARY_DIR}/core/runtime/blit_shaders)
 
+## ------------------------- Device Library Options ----------------------------
+set(ROCR_RUNTIME_DEVICE_LIB_PATH "" CACHE PATH "Builds against custom device-lib bitcode files (passed to clang --rocm-device-lib-path=)")
+set(ROCR_RUNTIME_DEVICE_LIB_DEPS "" CACHE STRING "Custom deps to depend on to ensure device libs are built")
+
+if (ROCR_RUNTIME_DEVICE_LIB_PATH)
+  message(STATUS "ROCR Runtime custom device lib path: ${ROCR_RUNTIME_DEVICE_LIB_PATH}")
+  if(NOT IS_DIRECTORY "${ROCR_RUNTIME_DEVICE_LIB_PATH}")
+    message(WARNING "Custom ROCR_RUNTIME_DEVICE_LIB_PATH does not exist")
+  endif()
+  set(ROCR_RUNTIME_CLANG_DEVICE_LIB_ARGS "--rocm-device-lib-path=${ROCR_RUNTIME_DEVICE_LIB_PATH}")
+else()
+  set(ROCR_RUNTIME_CLANG_DEVICE_LIB_ARGS)
+endif()
 
 ## ------------------------- Linux Compiler and Linker options -------------------------
 set ( HSA_CXX_FLAGS ${HSA_COMMON_CXX_FLAGS} -fexceptions -fno-rtti -fvisibility=hidden -Wno-error=missing-braces -Wno-error=sign-compare -Wno-sign-compare -Wno-write-strings -Wno-conversion-null -fno-math-errno -fno-threadsafe-statics -fmerge-all-constants -fms-extensions -Wno-error=comment -Wno-comment -Wno-error=pointer-arith -Wno-pointer-arith -Wno-error=unused-variable -Wno-error=unused-function )
@@ -156,6 +175,24 @@ target_compile_options(${CORE_RUNTIME_TARGET} PRIVATE ${HSA_CXX_FLAGS})
 #target_link_options not available prior to CMake 3.13
 set_property(TARGET ${CORE_RUNTIME_TARGET} PROPERTY LINK_FLAGS ${HSA_SHARED_LINK_FLAGS})
 ##  -------------------------  End Compiler and Linker options ----------------------------
+
+## Ensure that 'clang' and 'llvm-objcopy' targets are available
+if(NOT TARGET clang OR NOT TARGET llvm-objcopy)
+  if(TARGET clang OR TARGET llvm-objcopy)
+    message(FATAL_ERROR "Detected one of 'clang' or 'llvm-objcopy' targets but not both")
+  endif()
+  message(STATUS "LLVM deps not found: finding Clang and LLVM packages")
+  find_package(Clang REQUIRED HINTS ${CMAKE_PREFIX_PATH}/llvm PATHS /opt/rocm/llvm )
+  find_package(LLVM REQUIRED HINTS ${CMAKE_PREFIX_PATH}/llvm PATHS /opt/rocm/llvm )
+endif()
+
+if(${CMAKE_VERBOSE_MAKEFILE})
+  get_property(clang_path TARGET clang PROPERTY LOCATION)
+  get_property(objcopy_path TARGET llvm-objcopy PROPERTY LOCATION)
+  message("Using clang from: ${clang_path}")
+  message("Using llvm-objcopy from: ${objcopy_path}")
+  message("Trap handlers assembled for: ${TARGET_DEVS}")
+endif()
 
 ## Source files.
 set ( SRCS core/util/lnx/os_linux.cpp

--- a/src/core/runtime/blit_shaders/CMakeLists.txt
+++ b/src/core/runtime/blit_shaders/CMakeLists.txt
@@ -44,23 +44,10 @@
 # Minimum required version of CMake
 cmake_minimum_required ( VERSION 3.7 )
 
-# Find Clang package and LLVM package
-find_package(Clang REQUIRED HINTS ${CMAKE_PREFIX_PATH}/llvm PATHS /opt/rocm/llvm )
-find_package(LLVM REQUIRED HINTS ${CMAKE_PREFIX_PATH}/llvm PATHS /opt/rocm/llvm )
-
 # Set the target devices
 set (TARGET_DEVS "gfx900;gfx940;gfx1010;gfx1030;gfx1100")
 # Set the postfix for each target device
 set (POSTFIX "9;940;1010;10;11")
-
-# If verbose output is enabled, print paths and target devices
-if(${CMAKE_VERBOSE_MAKEFILE})
-	get_property(clang_path TARGET clang PROPERTY LOCATION)
-	get_property(objcopy_path TARGET llvm-objcopy PROPERTY LOCATION)
-	message("Using clang from: ${clang_path}")
-	message("Using llvm-objcopy from: ${objcopy_path}")
-	message("Blit Shaders assembled for: ${TARGET_DEVS}")
-endif()
 
 # Function to generate kernel bitcode
 function(gen_kernel_bc TARGET_ID INPUT_FILE OUTPUT_FILE)

--- a/src/core/runtime/trap_handler/CMakeLists.txt
+++ b/src/core/runtime/trap_handler/CMakeLists.txt
@@ -42,20 +42,8 @@
 
 cmake_minimum_required ( VERSION 3.7 )
 
-# Import target 'clang' and 'llvm-objcopy'
-find_package(Clang REQUIRED HINTS ${CMAKE_PREFIX_PATH}/llvm PATHS /opt/rocm/llvm )
-find_package(LLVM REQUIRED HINTS ${CMAKE_PREFIX_PATH}/llvm PATHS /opt/rocm/llvm )
-
 set (TARGET_DEVS "gfx900;gfx940;gfx941;gfx942;gfx1010;gfx1030;gfx1100")
 set (POSTFIX "9;940;941;942;1010;10;11")
-
-if(${CMAKE_VERBOSE_MAKEFILE})
-  get_property(clang_path TARGET clang PROPERTY LOCATION)
-  get_property(objcopy_path TARGET llvm-objcopy PROPERTY LOCATION)
-  message("Using clang from: ${clang_path}")
-  message("Using llvm-objcopy from: ${objcopy_path}")
-  message("Trap handlers assembled for: ${TARGET_DEVS}")
-endif()
 
 ##==========================================
 ##  Add custom command to generate a kernel code object file

--- a/src/image/blit_src/CMakeLists.txt
+++ b/src/image/blit_src/CMakeLists.txt
@@ -42,38 +42,26 @@
 
 cmake_minimum_required ( VERSION 3.7 )
 
-# Import target 'clang'
-find_package(Clang REQUIRED HINTS ${CMAKE_PREFIX_PATH}/llvm PATHS /opt/rocm/llvm )
-
 # Determine the target devices if not specified
 if (NOT DEFINED TARGET_DEVICES)
   set(TARGET_DEVICES "gfx700;gfx701;gfx702;gfx801;gfx802;gfx803;gfx805;gfx810;gfx900;gfx902;gfx904;gfx906;gfx908;gfx909;gfx90a;gfx90c;gfx940;gfx941;gfx942;gfx1010;gfx1011;gfx1012;gfx1013;gfx1030;gfx1031;gfx1032;gfx1033;gfx1034;gfx1035;gfx1036;gfx1100;gfx1101;gfx1102;gfx1103")
 endif()
 set( TARGET_DEVICES ${TARGET_DEVICES} CACHE STRING "Build targets" FORCE )
 
-if(${CMAKE_VERBOSE_MAKEFILE})
-  get_property(clang_path TARGET clang PROPERTY LOCATION)
-  message("Using clang from: ${clang_path}")
-  message("Build Setting:")
-  message("  Target Devices*: ${TARGET_DEVICES}")
-  message("  (Specify \";\" separated list of target IDs.)")
-  message("       Clang path: ${clang_path}")
-endif()
-
 ##==========================================
 ##  Add custom command to generate a kernel code object file
 ##==========================================
 function(gen_kernel_bc TARGET_ID INPUT_FILE OUTPUT_FILE)
-
   separate_arguments(CLANG_ARG_LIST UNIX_COMMAND
     "-O2 -x cl -Xclang -finclude-default-header -cl-denorms-are-zero -cl-std=CL2.0
     -target amdgcn-amd-amdhsa -mcpu=${TARGET_ID} -mcode-object-version=4
+    ${ROCR_RUNTIME_CLANG_DEVICE_LIB_ARGS}
     -o ${OUTPUT_FILE} ${INPUT_FILE}")
 
   ## Add custom command to produce a code object file.
   ## This depends on the kernel source file & compiler.
   add_custom_command(OUTPUT ${OUTPUT_FILE} COMMAND clang ${CLANG_ARG_LIST}
-    DEPENDS ${INPUT_FILE} clang
+    DEPENDS ${INPUT_FILE} clang ${ROCR_RUNTIME_DEVICE_LIB_DEPS}
     COMMENT "BUILDING bitcode for ${OUTPUT_FILE}..."
     VERBATIM)
 
@@ -130,7 +118,10 @@ function(generate_blit_file BFILE)
                      DEPENDS ${HSACO_TARG_LIST} create_hsaco_ascii_file.sh )
 
   ## Export a target that builds (and depends on) opencl_blit_objects.cpp
-  add_custom_target( ${BFILE} DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${BFILE}.cpp )
+  add_custom_target(${BFILE} 
+                    DEPENDS 
+                      ${CMAKE_CURRENT_BINARY_DIR}/${BFILE}.cpp 
+                      ${ROCR_RUNTIME_DEVICE_LIB_DEPS} )
 
 endfunction(generate_blit_file)
 


### PR DESCRIPTION
* Conditions find_package hsakmt on the pressence of the target.
* Move finding of clang/llvm-objcopy to a common place and use an in-tree target if available.
* Add options for depending on in-tree device libs.

This is a roll-up of changes that I needed to do in order to build ROCR-Runtime with other parts of the toolkit. In my final arrangement, I am only using the first point, but I believe the second/third are general improvements -- so including those as well.