### PR TITLE
Add dependabot config to update doc requirements

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "pip" # See documentation for possible values
+    directory: "/docs/sphinx" # Location of package manifests
+    open-pull-requests-limit: 10
+    schedule:
+      interval: "daily"
+    target-branch: "master"
+    labels:
+      - "documentation"
+      - "dependencies"
+    reviewers:
+      - "samjwu"


### PR DESCRIPTION
Dependabot will make PRs to update rocm-docs-core in `docs/sphinx/requirements` when a new version is released