### PR TITLE
Replace std::mutex with KernelMutex

### DIFF
--- a/src/core/inc/amd_blit_kernel.h
+++ b/src/core/inc/amd_blit_kernel.h
@@ -213,7 +213,7 @@ class BlitKernel : public core::Blit {
   std::atomic<uint64_t> pending_search_index_;
 
   /// Lock to synchronize access to kernarg_ and completion_signal_
-  std::mutex lock_;
+  KernelMutex lock_;
 
   /// Number of CUs on the underlying agent.
   int num_cus_;

--- a/src/core/runtime/amd_blit_kernel.cpp
+++ b/src/core/runtime/amd_blit_kernel.cpp
@@ -954,7 +954,7 @@ hsa_status_t BlitKernel::Initialize(const core::Agent& agent) {
 }
 
 hsa_status_t BlitKernel::Destroy(const core::Agent& agent) {
-  std::lock_guard<std::mutex> guard(lock_);
+  ScopedAcquire<KernelMutex> lock(&lock_);
 
   const AMD::GpuAgent& gpuAgent = static_cast<const AMD::GpuAgent&>(agent);
 
@@ -977,7 +977,7 @@ hsa_status_t BlitKernel::Destroy(const core::Agent& agent) {
 hsa_status_t BlitKernel::SubmitLinearCopyCommand(void* dst, const void* src,
                                                  size_t size) {
   // Protect completion_signal_.
-  std::lock_guard<std::mutex> guard(lock_);
+  ScopedAcquire<KernelMutex> lock(&lock_);
 
   HSA::hsa_signal_store_relaxed(completion_signal_, 1);
 
@@ -1124,7 +1124,7 @@ hsa_status_t BlitKernel::SubmitLinearCopyCommand(
 
 hsa_status_t BlitKernel::SubmitLinearFillCommand(void* ptr, uint32_t value,
                                                  size_t count) {
-  std::lock_guard<std::mutex> guard(lock_);
+  ScopedAcquire<KernelMutex> lock(&lock_);
 
   // Reject misaligned base address.
   if ((uintptr_t(ptr) & 0x3) != 0) {


### PR DESCRIPTION
Replace std::mutex with KernelMutex to see if this fixes potential issue with mutex not being initialized in BlitKernel constructor on some systems.