### PR TITLE
Fix CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Default code owners
-@dayatsin-amd @jokim-amd @shwetagkhatri @cfreeamd
+* @dayatsin-amd @jokim-amd @shwetagkhatri @cfreeamd
 
 # Documentation files
 docs/* @ROCm/rocm-documentation @dayatsin-amd @shwetagkhatri


### PR DESCRIPTION
Fix typo in CODEOWNERS.  The other errors are because the 2 names need to join the ROCm org.