### PR TITLE
Specify external_projects_current_project for Intersphinx

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,6 +28,8 @@ release = version_number
 
 external_toc_path = "./sphinx/_toc.yml"
 
+external_projects_current_project = "rocr-runtime"
+
 docs_core = ROCmDocs(left_nav_title)
 docs_core.run_doxygen(doxygen_root="doxygen", doxygen_path="doxygen/xml")
 docs_core.setup()


### PR DESCRIPTION
This PR adds `external_projects_current_project` in the Sphinx config to allow other ROCm documentation to more easily link to ROCR-Runtime documentation.

Related https://github.com/ROCm/rocm-docs-core/pull/780