### PR TITLE
Docs: Remove copying of index file for docs/6.2.1

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,7 +9,6 @@ import re
 
 from rocm_docs import ROCmDocs
 
-os.system("cp ../README.md index.md")
 os.system("cp ../src/README.md structure.md")
 
 with open('../src/CMakeLists.txt', encoding='utf-8') as f:


### PR DESCRIPTION
To fix 6.2.1 docs main index page.