### PR TITLE
rocr: Adding pointer to the owner driver in Agent class

### DIFF
--- a/runtime/hsa-runtime/core/inc/agent.h
+++ b/runtime/hsa-runtime/core/inc/agent.h
@@ -2,24 +2,24 @@
 //
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
-// 
+//
 // Copyright (c) 2014-2020, Advanced Micro Devices, Inc. All rights reserved.
-// 
+//
 // Developed by:
-// 
+//
 //                 AMD Research and AMD HSA Software Development
-// 
+//
 //                 Advanced Micro Devices, Inc.
-// 
+//
 //                 www.amd.com
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to
 // deal with the Software without restriction, including without limitation
 // the rights to use, copy, modify, merge, publish, distribute, sublicense,
 // and/or sell copies of the Software, and to permit persons to whom the
 // Software is furnished to do so, subject to the following conditions:
-// 
+//
 //  - Redistributions of source code must retain the above copyright notice,
 //    this list of conditions and the following disclaimers.
 //  - Redistributions in binary form must reproduce the above copyright
@@ -29,7 +29,7 @@
 //    nor the names of its contributors may be used to endorse or promote
 //    products derived from this Software without specific prior written
 //    permission.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
@@ -118,18 +118,9 @@ class Agent : public Checked<0xF6BC25EB17E6F917> {
   // @brief Agent class contructor.
   //
   // @param [in] type CPU or GPU or other.
-  explicit Agent(DriverType drv_type, uint32_t node_id, DeviceType type)
-      : driver_type(drv_type), node_id_(node_id), device_type_(uint32_t(type)),
+  explicit Agent(Driver &driver, uint32_t node_id, DeviceType type)
+      : node_id_(node_id), device_type_(uint32_t(type)), driver_(&driver),
         profiling_enabled_(false), enabled_(false) {
-    public_handle_ = Convert(this);
-  }
-
-  // @brief Agent class contructor.
-  //
-  // @param [in] type CPU or GPU or other.
-  explicit Agent(DriverType drv_type, uint32_t node_id, uint32_t type)
-      : driver_type(drv_type), node_id_(node_id), device_type_(type),
-        profiling_enabled_(false) {
     public_handle_ = Convert(this);
   }
 
@@ -294,6 +285,9 @@ class Agent : public Checked<0xF6BC25EB17E6F917> {
   // @brief Returns node id associated with this agent.
   __forceinline uint32_t node_id() const { return node_id_; }
 
+  // @brief Returns the driver associated with this agent.
+  __forceinline Driver &driver() { return *driver_; }
+
   // @brief Getter for profiling_enabled_.
   __forceinline bool profiling_enabled() const { return profiling_enabled_; }
 
@@ -314,8 +308,6 @@ class Agent : public Checked<0xF6BC25EB17E6F917> {
   virtual void Trim() {
     for (auto region : regions()) region->Trim();
   }
-
-  const DriverType driver_type;
 
 protected:
   // Intention here is to have a polymorphic update procedure for public_handle_
@@ -349,6 +341,8 @@ protected:
   const uint32_t node_id_;
 
   const uint32_t device_type_;
+
+  Driver *driver_;
 
   bool profiling_enabled_;
 

--- a/runtime/hsa-runtime/core/inc/amd_gpu_agent.h
+++ b/runtime/hsa-runtime/core/inc/amd_gpu_agent.h
@@ -74,8 +74,9 @@ class GpuAgentInt : public core::Agent {
  public:
   // @brief Constructor
    GpuAgentInt(uint32_t node_id)
-       : core::Agent(core::DriverType::KFD, node_id,
-                     core::Agent::DeviceType::kAmdGpuDevice) {}
+       : core::Agent(core::Runtime::runtime_singleton_->AgentDriver(
+                         core::DriverType::KFD),
+                     node_id, core::Agent::DeviceType::kAmdGpuDevice) {}
 
    // @brief Ensure blits are ready (performance hint).
    virtual void PreloadBlits() {}

--- a/runtime/hsa-runtime/core/inc/amd_kfd_driver.h
+++ b/runtime/hsa-runtime/core/inc/amd_kfd_driver.h
@@ -60,7 +60,7 @@ class Queue;
 
 namespace AMD {
 
-class KfdDriver : public core::Driver {
+class KfdDriver final : public core::Driver {
 public:
   KfdDriver(std::string devnode_name);
 

--- a/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
+++ b/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
@@ -55,9 +55,8 @@ class Queue;
 
 namespace AMD {
 
-class XdnaDriver : public core::Driver {
+class XdnaDriver final : public core::Driver {
 public:
-  XdnaDriver() = delete;
   XdnaDriver(std::string devnode_name);
   ~XdnaDriver();
 

--- a/runtime/hsa-runtime/core/runtime/amd_aie_agent.cpp
+++ b/runtime/hsa-runtime/core/runtime/amd_aie_agent.cpp
@@ -54,8 +54,9 @@ namespace rocr {
 namespace AMD {
 
 AieAgent::AieAgent(uint32_t node)
-    : core::Agent(core::DriverType::XDNA, node,
-                  core::Agent::DeviceType::kAmdAieDevice) {
+    : core::Agent(core::Runtime::runtime_singleton_->AgentDriver(
+                      core::DriverType::XDNA),
+                  node, core::Agent::DeviceType::kAmdAieDevice) {
   InitRegionList();
   InitAllocators();
   GetAgentProperties();
@@ -219,8 +220,8 @@ void AieAgent::InitRegionList() {
 }
 
 void AieAgent::GetAgentProperties() {
-  core::Runtime::runtime_singleton_->AgentDriver(driver_type)
-      .GetAgentProperties(*this);
+  auto &drv = static_cast<XdnaDriver &>(driver());
+  drv.GetAgentProperties(*this);
 }
 
 void AieAgent::InitAllocators() {

--- a/runtime/hsa-runtime/core/runtime/amd_aie_aql_queue.cpp
+++ b/runtime/hsa-runtime/core/runtime/amd_aie_aql_queue.cpp
@@ -100,8 +100,8 @@ AieAqlQueue::AieAqlQueue(AieAgent *agent, size_t req_size_pkts,
   signal_.queue_ptr = &amd_queue_;
   active_ = true;
 
-  core::Runtime::runtime_singleton_->AgentDriver(agent_.driver_type)
-      .CreateQueue(*this);
+  auto &drv = static_cast<XdnaDriver &>(agent_.driver());
+  drv.CreateQueue(*this);
 }
 
 AieAqlQueue::~AieAqlQueue() { Inactivate(); }
@@ -111,8 +111,8 @@ hsa_status_t AieAqlQueue::Inactivate() {
   hsa_status_t status(HSA_STATUS_SUCCESS);
 
   if (active) {
-    status = core::Runtime::runtime_singleton_->AgentDriver(agent_.driver_type)
-                 .DestroyQueue(*this);
+    auto &drv = static_cast<XdnaDriver &>(agent_.driver());
+    status = drv.DestroyQueue(*this);
     hw_ctx_handle_ = std::numeric_limits<uint32_t>::max();
   }
 

--- a/runtime/hsa-runtime/core/runtime/amd_cpu_agent.cpp
+++ b/runtime/hsa-runtime/core/runtime/amd_cpu_agent.cpp
@@ -2,24 +2,24 @@
 //
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
-// 
+//
 // Copyright (c) 2014-2020, Advanced Micro Devices, Inc. All rights reserved.
-// 
+//
 // Developed by:
-// 
+//
 //                 AMD Research and AMD HSA Software Development
-// 
+//
 //                 Advanced Micro Devices, Inc.
-// 
+//
 //                 www.amd.com
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to
 // deal with the Software without restriction, including without limitation
 // the rights to use, copy, modify, merge, publish, distribute, sublicense,
 // and/or sell copies of the Software, and to permit persons to whom the
 // Software is furnished to do so, subject to the following conditions:
-// 
+//
 //  - Redistributions of source code must retain the above copyright notice,
 //    this list of conditions and the following disclaimers.
 //  - Redistributions in binary form must reproduce the above copyright
@@ -29,7 +29,7 @@
 //    nor the names of its contributors may be used to endorse or promote
 //    products derived from this Software without specific prior written
 //    permission.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
@@ -55,7 +55,9 @@
 namespace rocr {
 namespace AMD {
 CpuAgent::CpuAgent(HSAuint32 node, const HsaNodeProperties &node_props)
-    : core::Agent(core::DriverType::KFD, node, kAmdCpuDevice),
+    : core::Agent(
+          core::Runtime::runtime_singleton_->AgentDriver(core::DriverType::KFD),
+          node, kAmdCpuDevice),
       properties_(node_props) {
   InitRegionList();
 
@@ -182,12 +184,12 @@ hsa_status_t CpuAgent::IterateCache(hsa_status_t (*callback)(hsa_cache_t cache, 
 }
 
 hsa_status_t CpuAgent::GetInfo(hsa_agent_info_t attribute, void* value) const {
-  
+
   // agent, and vendor name size limit
   const size_t attribute_u = static_cast<size_t>(attribute);
-  
+
   switch (attribute_u) {
-    
+
     // The code copies HsaNodeProperties.MarketingName a Unicode string
     // which is encoded in UTF-16 as a 7-bit ASCII string. The value of
     // HsaNodeProperties.MarketingName is obtained from the "model name"

--- a/runtime/hsa-runtime/core/runtime/amd_memory_region.cpp
+++ b/runtime/hsa-runtime/core/runtime/amd_memory_region.cpp
@@ -177,8 +177,8 @@ hsa_status_t MemoryRegion::AllocateImpl(size_t& size, AllocateFlags alloc_flags,
 
   size = AlignUp(size, kPageSize());
 
-  return core::Runtime::runtime_singleton_->AgentDriver(owner()->driver_type)
-      .AllocateMemory(*this, alloc_flags, address, size, agent_node_id);
+  return owner()->driver().AllocateMemory(*this, alloc_flags, address, size,
+                                          agent_node_id);
 }
 
 hsa_status_t MemoryRegion::Free(void* address, size_t size) const {
@@ -189,8 +189,7 @@ hsa_status_t MemoryRegion::Free(void* address, size_t size) const {
 hsa_status_t MemoryRegion::FreeImpl(void* address, size_t size) const {
   if (fragment_allocator_.free(address)) return HSA_STATUS_SUCCESS;
 
-  return core::Runtime::runtime_singleton_->AgentDriver(owner()->driver_type)
-      .FreeMemory(address, size);
+  return owner()->driver().FreeMemory(address, size);
 }
 
 // TODO:  Look into a better name and/or making this process transparent to exporting.


### PR DESCRIPTION
This PR establishes the association between `Agent` objects and `Driver` objects via a pointer (`Agent::driver_`), rather than an enum (`Agent::driver_type`) to avoid look-ups of the `Driver` object during use outside of construction.