### PR TITLE
rocr/aie: Add AIEAgent missing info

### DIFF
--- a/runtime/hsa-runtime/core/runtime/amd_aie_agent.cpp
+++ b/runtime/hsa-runtime/core/runtime/amd_aie_agent.cpp
@@ -42,6 +42,7 @@
 
 #include "core/inc/amd_aie_agent.h"
 
+#include <cstring>
 #include <functional>
 
 #include "core/inc/amd_aie_aql_queue.h"
@@ -237,7 +238,7 @@ hsa_status_t AieAgent::GetInfo(hsa_agent_info_t attribute, void *value) const {
     *reinterpret_cast<bool *>(value) = true;
     break;
   case HSA_AMD_AGENT_INFO_MEMORY_PROPERTIES:
-    memset(value, 0, sizeof(uint8_t) * 8);
+    std::memset(value, 0, sizeof(uint8_t) * 8);
     break;
   default:
     *reinterpret_cast<uint32_t *>(value) = 0;

--- a/runtime/hsa-runtime/core/runtime/amd_aie_agent.cpp
+++ b/runtime/hsa-runtime/core/runtime/amd_aie_agent.cpp
@@ -44,6 +44,7 @@
 
 #include <cstring>
 #include <functional>
+#include <string>
 
 #include "core/inc/amd_aie_aql_queue.h"
 #include "core/inc/amd_memory_region.h"
@@ -109,13 +110,19 @@ hsa_status_t AieAgent::GetInfo(hsa_agent_info_t attribute, void *value) const {
 
   switch (attribute_) {
   case HSA_AGENT_INFO_NAME: {
-    std::string name_info_("aie2");
-    std::strcpy(reinterpret_cast<char *>(value), name_info_.c_str());
+    const std::string name_info_("aie2");
+    assert(name_info_.size() < HSA_PUBLIC_NAME_SIZE);
+    std::memset(value, 0, HSA_PUBLIC_NAME_SIZE);
+    std::strncat(reinterpret_cast<char *>(value), name_info_.c_str(),
+                 name_info_.size());
     break;
   }
   case HSA_AGENT_INFO_VENDOR_NAME: {
-    std::string vendor_name_info_("AMD");
-    std::strcpy(reinterpret_cast<char *>(value), vendor_name_info_.c_str());
+    const std::string vendor_name_info_("AMD");
+    assert(vendor_name_info_.size() < HSA_PUBLIC_NAME_SIZE);
+    std::memset(value, 0, HSA_PUBLIC_NAME_SIZE);
+    std::strncat(reinterpret_cast<char *>(value), vendor_name_info_.c_str(),
+                 vendor_name_info_.size());
     break;
   }
   case HSA_AGENT_INFO_FEATURE:
@@ -220,14 +227,20 @@ hsa_status_t AieAgent::GetInfo(hsa_agent_info_t attribute, void *value) const {
     *reinterpret_cast<uint32_t *>(value) = 0;
     break;
   case HSA_AMD_AGENT_INFO_PRODUCT_NAME: {
-    std::string product_name_info_("AIE-ML");
-    std::strcpy(reinterpret_cast<char *>(value), product_name_info_.c_str());
+    const std::string product_name_info_("AIE-ML");
+    assert(product_name_info_.size() < HSA_PUBLIC_NAME_SIZE);
+    std::memset(value, 0, HSA_PUBLIC_NAME_SIZE);
+    std::strncat(reinterpret_cast<char *>(value), product_name_info_.c_str(),
+                 product_name_info_.size());
     break;
   }
   case HSA_AMD_AGENT_INFO_UUID: {
     // At this point AIE devices do not support UUID's.
-    char uuid_tmp[] = "AIE-XX";
-    snprintf(reinterpret_cast<char *>(value), sizeof(uuid_tmp), "%s", uuid_tmp);
+    const std::string uuid_info_("AIE-XX");
+    assert(uuid_info_.size() < HSA_PUBLIC_NAME_SIZE);
+    std::memset(value, 0, HSA_PUBLIC_NAME_SIZE);
+    std::strncat(reinterpret_cast<char *>(value), uuid_info_.c_str(),
+                 uuid_info_.size());
     break;
   }
   case HSA_AMD_AGENT_INFO_ASIC_REVISION:

--- a/runtime/hsa-runtime/core/runtime/amd_aie_agent.cpp
+++ b/runtime/hsa-runtime/core/runtime/amd_aie_agent.cpp
@@ -236,11 +236,8 @@ hsa_status_t AieAgent::GetInfo(hsa_agent_info_t attribute, void *value) const {
   }
   case HSA_AMD_AGENT_INFO_UUID: {
     // At this point AIE devices do not support UUID's.
-    const std::string uuid_info_("AIE-XX");
-    assert(uuid_info_.size() < HSA_PUBLIC_NAME_SIZE);
-    std::memset(value, 0, HSA_PUBLIC_NAME_SIZE);
-    std::strncat(reinterpret_cast<char *>(value), uuid_info_.c_str(),
-                 uuid_info_.size());
+    char uuid_tmp[] = "AIE-XX";
+    snprintf((char *)value, sizeof(uuid_tmp), "%s", uuid_tmp);
     break;
   }
   case HSA_AMD_AGENT_INFO_ASIC_REVISION:

--- a/runtime/hsa-runtime/core/runtime/amd_aie_agent.cpp
+++ b/runtime/hsa-runtime/core/runtime/amd_aie_agent.cpp
@@ -3,7 +3,7 @@
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
 //
-// Copyright (c) 2022-2023, Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2022-2024, Advanced Micro Devices, Inc. All rights reserved.
 //
 // Developed by:
 //
@@ -123,14 +123,30 @@ hsa_status_t AieAgent::GetInfo(hsa_agent_info_t attribute, void *value) const {
   case HSA_AGENT_INFO_MACHINE_MODEL:
     *reinterpret_cast<hsa_machine_model_t *>(value) = HSA_MACHINE_MODEL_LARGE;
     break;
+  case HSA_AGENT_INFO_BASE_PROFILE_DEFAULT_FLOAT_ROUNDING_MODES:
+  case HSA_AGENT_INFO_DEFAULT_FLOAT_ROUNDING_MODE:
+    // TODO: validate if this is true.
+    *reinterpret_cast<hsa_default_float_rounding_mode_t *>(value) =
+        HSA_DEFAULT_FLOAT_ROUNDING_MODE_NEAR;
+    break;
   case HSA_AGENT_INFO_PROFILE:
     *reinterpret_cast<hsa_profile_t *>(value) = profile_;
     break;
   case HSA_AGENT_INFO_WAVEFRONT_SIZE:
+    *reinterpret_cast<uint32_t *>(value) = 0;
+    break;
   case HSA_AGENT_INFO_WORKGROUP_MAX_DIM:
+    std::memset(value, 0, sizeof(uint16_t) * 3);
+    break;
   case HSA_AGENT_INFO_WORKGROUP_MAX_SIZE:
+    *reinterpret_cast<uint32_t *>(value) = 0;
+    break;
   case HSA_AGENT_INFO_GRID_MAX_DIM:
+    std::memset(value, 0, sizeof(uint16_t) * 3);
+    break;
   case HSA_AGENT_INFO_GRID_MAX_SIZE:
+    *reinterpret_cast<uint32_t *>(value) = 0;
+    break;
   case HSA_AGENT_INFO_FBARRIER_MAX_SIZE:
     *reinterpret_cast<uint32_t *>(value) = 0;
     break;
@@ -161,6 +177,36 @@ hsa_status_t AieAgent::GetInfo(hsa_agent_info_t attribute, void *value) const {
   case HSA_AGENT_INFO_VERSION_MINOR:
     *reinterpret_cast<uint32_t *>(value) = 0;
     break;
+  case HSA_AMD_AGENT_INFO_CHIP_ID:
+    *reinterpret_cast<uint32_t *>(value) = 0;
+    break;
+  case HSA_AMD_AGENT_INFO_CACHELINE_SIZE:
+    *reinterpret_cast<uint32_t *>(value) = 0;
+    break;
+  case HSA_AMD_AGENT_INFO_COMPUTE_UNIT_COUNT:
+    *reinterpret_cast<uint32_t *>(value) = 0;
+    break;
+  case HSA_AMD_AGENT_INFO_MAX_CLOCK_FREQUENCY:
+    *reinterpret_cast<uint32_t *>(value) = 0;
+    break;
+  case HSA_AMD_AGENT_INFO_DRIVER_NODE_ID:
+    *reinterpret_cast<uint32_t *>(value) = node_id();
+    break;
+  case HSA_AMD_AGENT_INFO_MAX_ADDRESS_WATCH_POINTS:
+    *reinterpret_cast<uint32_t *>(value) = 0;
+    break;
+  case HSA_AMD_AGENT_INFO_BDFID:
+    *reinterpret_cast<uint32_t *>(value) = 0;
+    break;
+  case HSA_AMD_AGENT_INFO_NUM_SIMDS_PER_CU:
+    *reinterpret_cast<uint32_t *>(value) = 0;
+    break;
+  case HSA_AMD_AGENT_INFO_NUM_SHADER_ENGINES:
+    *reinterpret_cast<uint32_t *>(value) = 0;
+    break;
+  case HSA_AMD_AGENT_INFO_NUM_SHADER_ARRAYS_PER_SE:
+    *reinterpret_cast<uint32_t *>(value) = 0;
+    break;
   case HSA_EXT_AGENT_INFO_IMAGE_1D_MAX_ELEMENTS:
   case HSA_EXT_AGENT_INFO_IMAGE_1DA_MAX_ELEMENTS:
   case HSA_EXT_AGENT_INFO_IMAGE_1DB_MAX_ELEMENTS:
@@ -177,6 +223,22 @@ hsa_status_t AieAgent::GetInfo(hsa_agent_info_t attribute, void *value) const {
     std::strcpy(reinterpret_cast<char *>(value), product_name_info_.c_str());
     break;
   }
+  case HSA_AMD_AGENT_INFO_UUID: {
+    // At this point AIE devices do not support UUID's.
+    char uuid_tmp[] = "AIE-XX";
+    snprintf(reinterpret_cast<char *>(value), sizeof(uuid_tmp), "%s", uuid_tmp);
+    break;
+  }
+  case HSA_AMD_AGENT_INFO_ASIC_REVISION:
+    *reinterpret_cast<uint32_t *>(value) = 0;
+    break;
+  case HSA_AMD_AGENT_INFO_SVM_DIRECT_HOST_ACCESS:
+    assert(regions_.size() != 0 && "No device local memory found!");
+    *reinterpret_cast<bool *>(value) = true;
+    break;
+  case HSA_AMD_AGENT_INFO_MEMORY_PROPERTIES:
+    memset(value, 0, sizeof(uint8_t) * 8);
+    break;
   default:
     *reinterpret_cast<uint32_t *>(value) = 0;
     return HSA_STATUS_ERROR_INVALID_ARGUMENT;


### PR DESCRIPTION
This PR adds the missing information so that `rocminfo` works properly for when an AIE agent is present.

Some of the `_NAME` values are also zero'd out in accordance with what other agents do and the `strcpy` (copy byte-by-byte) was replaced with `strncat` (the number of characters to copy is given, so it can do a memcpy).