### PR TITLE
rocr/aie: AIE agent memory pools correct size and user data pool

### DIFF
--- a/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -46,6 +46,8 @@
 #include <sys/ioctl.h>
 #include <sys/mman.h>
 
+#include <cstdio>
+#include <cstring>
 #include <memory>
 #include <string>
 
@@ -63,7 +65,7 @@ XdnaDriver::XdnaDriver(std::string devnode_name)
 
 hsa_status_t XdnaDriver::DiscoverDriver(std::unique_ptr<core::Driver>& driver) {
   const int max_minor_num(64);
-  const std::string devnode_prefix("/dev/accel/accel");
+  static const std::string devnode_prefix("/dev/accel/accel");
 
   for (int i = 0; i < max_minor_num; ++i) {
     auto tmp_driver = std::unique_ptr<Driver>(new XdnaDriver(devnode_prefix + std::to_string(i)));
@@ -79,6 +81,32 @@ hsa_status_t XdnaDriver::DiscoverDriver(std::unique_ptr<core::Driver>& driver) {
   }
 
   return HSA_STATUS_ERROR;
+}
+
+uint64_t XdnaDriver::GetSystemMemoryByteSize() {
+  static const std::string meminfo_node("/proc/meminfo");
+
+  FILE *file = std::fopen(meminfo_node.c_str(), "r");
+  if (file == nullptr)
+    throw AMD::hsa_exception(HSA_STATUS_ERROR_INVALID_FILE,
+                             "Invalid memory info file.");
+
+  const int expected_args = 2;
+  int result = 0;
+  char property_name[256];
+  unsigned long long property_val = 0;
+  while ((result = std::fscanf(file, "%255s %llu\n", property_name,
+                               &property_val)) == expected_args) {
+    if (std::strcmp(property_name, "MemTotal:") == 0)
+      break;
+  }
+  std::fclose(file);
+
+  if ((result == EOF) || (result != expected_args))
+    throw AMD::hsa_exception(HSA_STATUS_ERROR, "Could not parse file.");
+
+  // memory reported is in Kbytes
+  return property_val * 1024ull;
 }
 
 uint64_t XdnaDriver::GetDevHeapByteSize() {

--- a/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -45,9 +45,8 @@
 #include <fcntl.h>
 #include <sys/ioctl.h>
 #include <sys/mman.h>
+#include <unistd.h>
 
-#include <cstdio>
-#include <cstring>
 #include <memory>
 #include <string>
 
@@ -84,29 +83,9 @@ hsa_status_t XdnaDriver::DiscoverDriver(std::unique_ptr<core::Driver>& driver) {
 }
 
 uint64_t XdnaDriver::GetSystemMemoryByteSize() {
-  static const std::string meminfo_node("/proc/meminfo");
-
-  FILE *file = std::fopen(meminfo_node.c_str(), "r");
-  if (file == nullptr)
-    throw AMD::hsa_exception(HSA_STATUS_ERROR_INVALID_FILE,
-                             "Invalid memory info file.");
-
-  const int expected_args = 2;
-  int result = 0;
-  char property_name[256];
-  unsigned long long property_val = 0;
-  while ((result = std::fscanf(file, "%255s %llu\n", property_name,
-                               &property_val)) == expected_args) {
-    if (std::strcmp(property_name, "MemTotal:") == 0)
-      break;
-  }
-  std::fclose(file);
-
-  if ((result == EOF) || (result != expected_args))
-    throw AMD::hsa_exception(HSA_STATUS_ERROR, "Could not parse file.");
-
-  // memory reported is in Kbytes
-  return property_val * 1024ull;
+  const long pagesize = sysconf(_SC_PAGESIZE);
+  const long page_count = sysconf(_SC_PHYS_PAGES);
+  return pagesize * page_count;
 }
 
 uint64_t XdnaDriver::GetDevHeapByteSize() {

--- a/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
+++ b/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
@@ -133,6 +133,9 @@ public:
 
   static hsa_status_t DiscoverDriver(std::unique_ptr<core::Driver>& driver);
 
+  /// @brief Returns the size of the system memory heap in bytes.
+  static uint64_t GetSystemMemoryByteSize();
+
   /// @brief Returns the size of the dev heap in bytes.
   static uint64_t GetDevHeapByteSize();
 

--- a/runtime/hsa-runtime/core/runtime/amd_aie_agent.cpp
+++ b/runtime/hsa-runtime/core/runtime/amd_aie_agent.cpp
@@ -282,11 +282,18 @@ void AieAgent::InitRegionList() {
   ///       This should be easier once the ROCt source is incorporated into the
   ///       ROCr source. Since the AIE itself currently has no memory regions of
   ///       its own all memory is just the system DRAM.
+  const uint64_t total_system_memory = XdnaDriver::GetSystemMemoryByteSize();
 
   /// For allocating kernel arguments or other objects that only need
   /// system memory.
   HsaMemoryProperties sys_mem_props = {};
   sys_mem_props.HeapType = HSA_HEAPTYPE_SYSTEM;
+  sys_mem_props.SizeInBytes = total_system_memory;
+
+  /// For any other allocation, e.g., buffers.
+  HsaMemoryProperties other_mem_props = {};
+  other_mem_props.HeapType = HSA_HEAPTYPE_SYSTEM;
+  other_mem_props.SizeInBytes = total_system_memory;
 
   /// For allocating memory for programmable device image (PDI) files. These
   /// need to be mapped to the device so the hardware can access the PDIs.
@@ -296,11 +303,13 @@ void AieAgent::InitRegionList() {
 
   /// As of now the AIE devices support coarse-grain memory regions that require
   /// explicit sync operations.
-  regions_.reserve(2);
+  regions_.reserve(3);
   regions_.push_back(
       new MemoryRegion(false, true, false, false, true, this, sys_mem_props));
   regions_.push_back(
       new MemoryRegion(false, false, false, false, true, this, dev_mem_props));
+  regions_.push_back(new MemoryRegion(false, false, false, false, true, this,
+                                      other_mem_props));
 }
 
 void AieAgent::GetAgentProperties() {

--- a/runtime/hsa-runtime/core/runtime/amd_aie_agent.cpp
+++ b/runtime/hsa-runtime/core/runtime/amd_aie_agent.cpp
@@ -298,7 +298,7 @@ void AieAgent::InitRegionList() {
   /// For allocating memory for programmable device image (PDI) files. These
   /// need to be mapped to the device so the hardware can access the PDIs.
   HsaMemoryProperties dev_mem_props = {};
-  dev_mem_props.HeapType = HSA_HEAPTYPE_DEVICE_SVM,
+  dev_mem_props.HeapType = HSA_HEAPTYPE_DEVICE_SVM;
   dev_mem_props.SizeInBytes = XdnaDriver::GetDevHeapByteSize();
 
   /// As of now the AIE devices support coarse-grain memory regions that require


### PR DESCRIPTION
This PR fixes the memory sizes reported for the kernarg pool and adds a pool for user data that is not the DEV HEAP or kernarg pool.