### PR TITLE
hsa-runtime: set underlying type of hsa_region_info_t, hsa_amd_region_info_t to int

### DIFF
--- a/runtime/hsa-runtime/inc/hsa.h
+++ b/runtime/hsa-runtime/inc/hsa.h
@@ -3269,7 +3269,7 @@ typedef enum {
 /**
  * @brief Attributes of a memory region.
  */
-typedef enum {
+typedef enum : int {
   /**
    * Segment where memory in the region can be used. The type of this
    * attribute is ::hsa_region_segment_t.

--- a/runtime/hsa-runtime/inc/hsa_ext_amd.h
+++ b/runtime/hsa-runtime/inc/hsa_ext_amd.h
@@ -774,7 +774,7 @@ typedef struct hsa_amd_hdp_flush_s {
 /**
  * @brief Region attributes.
  */
-typedef enum hsa_amd_region_info_s {
+typedef enum hsa_amd_region_info_s : int {
   /**
    * Determine if host can access the region. The type of this attribute
    * is bool.


### PR DESCRIPTION
When an enum's backing type is not set explicitly it is undefined behavior to load a value that is not one within the range of values it was defined with after https://cplusplus.github.io/CWG/issues/1766.html

This causes UB because ROCR-Runtime casts back and forth between `hsa_amd_region_info_s` and `hsa_region_info_t` types.

https://github.com/ROCm/ROCR-Runtime/blob/2d40493c314f6a139ce9cce8ea004c53dadd200f/samples/common/common.cpp#L37

Fixes one of the errors reported in #272:

```
/build/source/runtime/hsa-runtime/core/runtime/amd_memory_region.cpp:206:11: runtime error: load of value 40961, which is not a valid value for type 'hsa_region_info_t'
    #0 0x7fff754f159e in GetInfo /build/source/runtime/hsa-runtime/core/runtime/amd_memory_region.cpp:206
    #1 0x7fff75504228 in hsa_region_get_info /build/source/runtime/hsa-runtime/core/runtime/hsa.cpp:1077
    #2 0x7fff75700018 in Initialize /build/source/runtime/hsa-runtime/image/image_manager_kv.cpp:179
```