### PR TITLE
Fixing HostQueue to obey the alignment requirement on calls to aligned_alloc.

### DIFF
--- a/runtime/hsa-runtime/core/inc/host_queue.h
+++ b/runtime/hsa-runtime/core/inc/host_queue.h
@@ -165,7 +165,7 @@ class HostQueue : public Queue {
   }
 
   void* operator new(size_t size) {
-    return _aligned_malloc(size, HSA_QUEUE_ALIGN_BYTES);
+    return _aligned_malloc(AlignUp(size, HSA_QUEUE_ALIGN_BYTES), HSA_QUEUE_ALIGN_BYTES);
   }
 
   void* operator new(size_t size, void* ptr) { return ptr; }


### PR DESCRIPTION
`aligned_alloc` is specified as requiring the `size` parameter to be a multiple of the `alignment` parameter:
https://en.cppreference.com/w/c/memory/aligned_alloc

Not using a multiple of the alignment is undefined behavior and the allocator is allowed to return NULL in any case where the size (or alignment) is invalid. ASAN helpfully reports cases relying on the undefined behavior and there's (at least one) case in ROCR:

```
==95182==ERROR: AddressSanitizer: invalid alignment requested in aligned_alloc: 64, alignment must be a power of two and the requested size 0x38 must be a multiple of alignment (thread T0)
    #0 0x58dcb7d0abd2 in aligned_alloc (/home/nod/src/iree-build/runtime/src/iree/hal/drivers/amdgpu/cts/amdgpu_all_command_buffer_test+0x23cbd2) (BuildId: 7fd0108d32fcb58c)
    #1 0x7d8fa9ec2728 in rocr::_aligned_malloc(unsigned long, unsigned long) /home/nod/src/ROCR-Runtime/runtime/hsa-runtime/core/util/utils.h:82:10
    #2 0x7d8fa9ec2728 in rocr::core::HostQueue::operator new(unsigned long) /home/nod/src/ROCR-Runtime/runtime/hsa-runtime/core/inc/host_queue.h:168:12
    #3 0x7d8fa9eb2380 in rocr::HSA::hsa_soft_queue_create(hsa_region_s, unsigned int, unsigned int, unsigned int, hsa_signal_s, hsa_queue_s**) /home/nod/src/ROCR-Runtime/runtime/hsa-runtime/core/runtime/hsa.cpp:777:33
    #4 0x7d8fa9f79a8e in hsa_soft_queue_create /home/nod/src/ROCR-Runtime/runtime/hsa-runtime/core/common/hsa_table_interface.cpp:169:10
    #5 0x58dcb7de967b in iree_hsa_soft_queue_create /home/nod/src/iree/runtime/src/iree/hal/drivers/amdgpu/util/libhsa_tables.h:396:1
    #6 0x58dcb7db5965 in iree_hal_amdgpu_host_worker_initialize /home/nod/src/iree/runtime/src/iree/hal/drivers/amdgpu/host_worker.c:655:14
```

The `HostQueue::operator new` overload is using the `sizeof(HostQueue)` which is 56 on my machine, not a multiple of the requested `HSA_QUEUE_ALIGN_BYTES` alignment of 64 bytes.