### PR TITLE
rocr/aie: correct detection of which memory to allocate from for HSA_HEAPTYPE_DEVICE_SVM

### DIFF
--- a/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -186,7 +186,8 @@ XdnaDriver::AllocateMemory(const core::MemoryRegion &mem_region,
     return HSA_STATUS_ERROR_INVALID_REGION;
   }
 
-  if (m_region.kernarg()) {
+  const bool use_bo_shmem = m_region.kernarg() || m_region.IsSystemButNotSVM();
+  if (use_bo_shmem) {
     create_bo_args.type = AMDXDNA_BO_SHMEM;
   } else {
     create_bo_args.type = AMDXDNA_BO_DEV;
@@ -210,7 +211,7 @@ XdnaDriver::AllocateMemory(const core::MemoryRegion &mem_region,
   /// TODO: For now we always map the memory and keep a mapping from handles
   /// to VA memory addresses. Once we can support the separate VMEM call to
   /// map handles we can fix this.
-  if (m_region.kernarg()) {
+  if (use_bo_shmem) {
     mapped_mem = mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd_,
                       get_bo_info_args.map_offset);
     if (mapped_mem == MAP_FAILED) {

--- a/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -186,7 +186,7 @@ XdnaDriver::AllocateMemory(const core::MemoryRegion &mem_region,
     return HSA_STATUS_ERROR_INVALID_REGION;
   }
 
-  const bool use_bo_shmem = m_region.kernarg() || m_region.IsSystemButNotSVM();
+  const bool use_bo_shmem = !m_region.IsDeviceSVM();
   if (use_bo_shmem) {
     create_bo_args.type = AMDXDNA_BO_SHMEM;
   } else {

--- a/runtime/hsa-runtime/core/inc/amd_memory_region.h
+++ b/runtime/hsa-runtime/core/inc/amd_memory_region.h
@@ -2,24 +2,24 @@
 //
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
-// 
+//
 // Copyright (c) 2014-2020, Advanced Micro Devices, Inc. All rights reserved.
-// 
+//
 // Developed by:
-// 
+//
 //                 AMD Research and AMD HSA Software Development
-// 
+//
 //                 Advanced Micro Devices, Inc.
-// 
+//
 //                 www.amd.com
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to
 // deal with the Software without restriction, including without limitation
 // the rights to use, copy, modify, merge, publish, distribute, sublicense,
 // and/or sell copies of the Software, and to permit persons to whom the
 // Software is furnished to do so, subject to the following conditions:
-// 
+//
 //  - Redistributions of source code must retain the above copyright notice,
 //    this list of conditions and the following disclaimers.
 //  - Redistributions in binary form must reproduce the above copyright
@@ -29,7 +29,7 @@
 //    nor the names of its contributors may be used to endorse or promote
 //    products derived from this Software without specific prior written
 //    permission.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
@@ -145,6 +145,10 @@ class MemoryRegion : public core::MemoryRegion {
   __forceinline bool IsSystem() const {
     return ((mem_props_.HeapType == HSA_HEAPTYPE_SYSTEM) ||
             (mem_props_.HeapType == HSA_HEAPTYPE_DEVICE_SVM));
+  }
+
+  __forceinline bool IsSystemButNotSVM() const {
+    return (mem_props_.HeapType == HSA_HEAPTYPE_SYSTEM);
   }
 
   __forceinline bool IsLDS() const {

--- a/runtime/hsa-runtime/core/inc/amd_memory_region.h
+++ b/runtime/hsa-runtime/core/inc/amd_memory_region.h
@@ -147,8 +147,8 @@ class MemoryRegion : public core::MemoryRegion {
             (mem_props_.HeapType == HSA_HEAPTYPE_DEVICE_SVM));
   }
 
-  __forceinline bool IsSystemButNotSVM() const {
-    return (mem_props_.HeapType == HSA_HEAPTYPE_SYSTEM);
+  __forceinline bool IsDeviceSVM() const {
+    return (mem_props_.HeapType == HSA_HEAPTYPE_DEVICE_SVM);
   }
 
   __forceinline bool IsLDS() const {


### PR DESCRIPTION
This PR adds a function to detect if memory is device SVM that is needed to choose between BO_SHMEM and BO_DEV for xdna.