### PR TITLE
hsakmt: Revert "hsakmt: Do not install headers"

### DIFF
--- a/libhsakmt/CMakeLists.txt
+++ b/libhsakmt/CMakeLists.txt
@@ -1,6 +1,6 @@
 ################################################################################
 ##
-## Copyright (c) 2016 Advanced Micro Devices, Inc. All rights reserved.
+## Copyright (c) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
 ##
 ## MIT LICENSE:
 ## Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -198,10 +198,6 @@ install ( TARGETS ${HSAKMT_TARGET} EXPORT ${HSAKMT_TARGET}Targets
 install ( TARGETS ${HSAKMT_TARGET}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT binary
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT binary )
-
-# Install public headers
-install ( DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/${HSAKMT_TARGET} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-  COMPONENT dev PATTERN "linux" EXCLUDE )
 
 # Option to build header path migration helpers.
 option(INCLUDE_PATH_COMPATIBILITY "Generate backward compatible headers and include paths.  Use of these headers will warn when included." OFF)

--- a/libhsakmt/CMakeLists.txt
+++ b/libhsakmt/CMakeLists.txt
@@ -1,6 +1,6 @@
 ################################################################################
 ##
-## Copyright (c) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+## Copyright (c) 2016 Advanced Micro Devices, Inc. All rights reserved.
 ##
 ## MIT LICENSE:
 ## Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -198,6 +198,10 @@ install ( TARGETS ${HSAKMT_TARGET} EXPORT ${HSAKMT_TARGET}Targets
 install ( TARGETS ${HSAKMT_TARGET}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT binary
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT binary )
+
+# Install public headers
+install ( DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/${HSAKMT_TARGET} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+  COMPONENT dev PATTERN "linux" EXCLUDE )
 
 # Option to build header path migration helpers.
 option(INCLUDE_PATH_COMPATIBILITY "Generate backward compatible headers and include paths.  Use of these headers will warn when included." OFF)

--- a/libhsakmt/include/hsakmt/hsakmttypes.h
+++ b/libhsakmt/include/hsakmt/hsakmttypes.h
@@ -267,6 +267,8 @@ typedef struct _HsaNodeProperties
                                        // e.g a "discrete HSA GPU"
     HSAuint32       NumFComputeCores;  // # of HSA throughtput (= GPU) FCompute cores ("SIMD") present in a node.
                                        // This value is 0 if no FCompute cores are present (e.g. pure "CPU node").
+    HSAuint32 NumNeuralCores;          // # of HSA neural processing units (= AIE) present in a
+                                       // node. This value is 0 if there are no NeuralCores.
     HSAuint32       NumMemoryBanks;    // # of discoverable memory bank affinity properties on this "H-NUMA" node.
     HSAuint32       NumCaches;         // # of discoverable cache affinity properties on this "H-NUMA"  node.
 

--- a/runtime/hsa-runtime/core/driver/driver.cpp
+++ b/runtime/hsa-runtime/core/driver/driver.cpp
@@ -42,9 +42,6 @@
 
 #include "core/inc/driver.h"
 
-#include <fcntl.h>
-#include <unistd.h>
-
 #include "inc/hsa.h"
 
 namespace rocr {
@@ -53,28 +50,6 @@ namespace core {
 Driver::Driver(DriverType kernel_driver_type, std::string devnode_name)
     : kernel_driver_type_(std::move(kernel_driver_type)),
       devnode_name_(std::move(devnode_name)) {}
-
-hsa_status_t Driver::Open()
-{
-  fd_  = open(devnode_name_.c_str(), O_RDWR | O_CLOEXEC);
-  if (fd_ < 0) {
-    return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
-  }
-  return HSA_STATUS_SUCCESS;
-}
-
-hsa_status_t Driver::Close()
-{
-  int ret(0);
-  if (fd_ > 0) {
-    ret = close(fd_);
-    fd_ = -1;
-  }
-  if (ret) {
-    return HSA_STATUS_ERROR;
-  }
-  return HSA_STATUS_SUCCESS;
-}
 
 } // namespace core
 } // namespace rocr

--- a/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
+++ b/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
@@ -64,8 +64,9 @@ KfdDriver::KfdDriver(std::string devnode_name)
 hsa_status_t KfdDriver::Init() { return HSA_STATUS_SUCCESS; }
 
 hsa_status_t KfdDriver::DiscoverDriver() {
-  if (hsaKmtOpenKFD() == HSAKMT_STATUS_SUCCESS) {
-    std::unique_ptr<Driver> kfd_drv(new KfdDriver("/dev/kfd"));
+  std::unique_ptr<Driver> kfd_drv(new KfdDriver("/dev/kfd"));
+
+  if (kfd_drv->Open() == HSA_STATUS_SUCCESS) {
     core::Runtime::runtime_singleton_->RegisterDriver(kfd_drv);
     return HSA_STATUS_SUCCESS;
   }
@@ -74,6 +75,16 @@ hsa_status_t KfdDriver::DiscoverDriver() {
 
 hsa_status_t KfdDriver::QueryKernelModeDriver(core::DriverQuery query) {
   return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t KfdDriver::Open() {
+  return hsaKmtOpenKFD() == HSAKMT_STATUS_SUCCESS ? HSA_STATUS_SUCCESS
+                                                  : HSA_STATUS_ERROR;
+}
+
+hsa_status_t KfdDriver::Close() {
+  return hsaKmtCloseKFD() == HSAKMT_STATUS_SUCCESS ? HSA_STATUS_SUCCESS
+                                                   : HSA_STATUS_ERROR;
 }
 
 hsa_status_t KfdDriver::GetAgentProperties(core::Agent &agent) const {

--- a/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -42,6 +42,7 @@
 
 #include "core/inc/amd_xdna_driver.h"
 
+#include <fcntl.h>
 #include <sys/ioctl.h>
 #include <sys/mman.h>
 
@@ -96,6 +97,26 @@ hsa_status_t XdnaDriver::QueryKernelModeDriver(core::DriverQuery query) {
     return QueryDriverVersion();
   default:
     return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+  }
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t XdnaDriver::Open() {
+  fd_ = open(devnode_name_.c_str(), O_RDWR | O_CLOEXEC);
+  if (fd_ < 0) {
+    return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
+  }
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t XdnaDriver::Close() {
+  int ret(0);
+  if (fd_ > 0) {
+    ret = close(fd_);
+    fd_ = -1;
+  }
+  if (ret) {
+    return HSA_STATUS_ERROR;
   }
   return HSA_STATUS_SUCCESS;
 }

--- a/runtime/hsa-runtime/core/inc/agent.h
+++ b/runtime/hsa-runtime/core/inc/agent.h
@@ -49,7 +49,6 @@
 #include <vector>
 
 #include "core/inc/checked.h"
-#include "core/inc/driver.h"
 #include "core/inc/isa.h"
 #include "core/inc/memory_region.h"
 #include "core/inc/queue.h"
@@ -64,6 +63,7 @@ class MemoryRegion;
 }
 
 namespace core {
+class Driver;
 class Signal;
 
 typedef void (*HsaEventCallback)(hsa_status_t status, hsa_queue_t* source,

--- a/runtime/hsa-runtime/core/inc/amd_aie_aql_queue.h
+++ b/runtime/hsa-runtime/core/inc/amd_aie_aql_queue.h
@@ -53,6 +53,8 @@
 namespace rocr {
 namespace AMD {
 
+class XdnaDriver;
+
 /// @brief Encapsulates HW AIE AQL Command Processor functionality. It
 /// provides the interface for things such as doorbells, queue read and
 /// write pointers, and a buffer.

--- a/runtime/hsa-runtime/core/inc/amd_available_drivers.h
+++ b/runtime/hsa-runtime/core/inc/amd_available_drivers.h
@@ -1,0 +1,53 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+// The University of Illinois/NCSA
+// Open Source License (NCSA)
+//
+// Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+//
+// Developed by:
+//
+//                 AMD Research and AMD HSA Software Development
+//
+//                 Advanced Micro Devices, Inc.
+//
+//                 www.amd.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal with the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+//  - Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimers.
+//  - Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimers in
+//    the documentation and/or other materials provided with the distribution.
+//  - Neither the names of Advanced Micro Devices, Inc,
+//    nor the names of its contributors may be used to endorse or promote
+//    products derived from this Software without specific prior written
+//    permission.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+// OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS WITH THE SOFTWARE.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef HSA_RUNTME_CORE_INC_AMD_AVAILABLE_DRIVERS_H_
+#define HSA_RUNTME_CORE_INC_AMD_AVAILABLE_DRIVERS_H_
+
+#ifdef __linux__
+
+#include "core/inc/amd_kfd_driver.h"
+#include "core/inc/amd_xdna_driver.h"
+
+#endif
+
+#endif  // header guard

--- a/runtime/hsa-runtime/core/inc/amd_kfd_driver.h
+++ b/runtime/hsa-runtime/core/inc/amd_kfd_driver.h
@@ -43,6 +43,7 @@
 #ifndef HSA_RUNTIME_CORE_INC_AMD_KFD_DRIVER_H_
 #define HSA_RUNTIME_CORE_INC_AMD_KFD_DRIVER_H_
 
+#include <memory>
 #include <string>
 
 #include "hsakmt/hsakmt.h"
@@ -64,12 +65,17 @@ class KfdDriver final : public core::Driver {
 public:
   KfdDriver(std::string devnode_name);
 
-  static hsa_status_t DiscoverDriver();
+  static hsa_status_t DiscoverDriver(std::unique_ptr<core::Driver>& driver);
 
   hsa_status_t Init() override;
+  hsa_status_t ShutDown() override;
   hsa_status_t QueryKernelModeDriver(core::DriverQuery query) override;
   hsa_status_t Open() override;
   hsa_status_t Close() override;
+  hsa_status_t GetSystemProperties(HsaSystemProperties& sys_props) const override;
+  hsa_status_t GetNodeProperties(HsaNodeProperties& node_props, uint32_t node_id) const override;
+  hsa_status_t GetEdgeProperties(std::vector<HsaIoLinkProperties>& io_link_props,
+                                 uint32_t node_id) const override;
   hsa_status_t GetAgentProperties(core::Agent &agent) const override;
   hsa_status_t
   GetMemoryProperties(uint32_t node_id,
@@ -98,6 +104,17 @@ private:
 
   /// @brief Unpin memory.
   static void MakeKfdMemoryUnresident(const void *mem);
+
+  /// @brief Query for user preference and use that to determine Xnack mode
+  /// of ROCm system. Return true if Xnack mode is ON or false if OFF. Xnack
+  /// mode of a system is orthogonal to devices that do not support Xnack mode.
+  /// It is legal for a system with Xnack ON to have devices that do not support
+  /// Xnack functionality.
+  static bool BindXnackMode();
+
+  // Minimum acceptable KFD version numbers.
+  static const uint32_t kfd_version_major_min = 0;
+  static const uint32_t kfd_version_minor_min = 99;
 };
 
 } // namespace AMD

--- a/runtime/hsa-runtime/core/inc/amd_kfd_driver.h
+++ b/runtime/hsa-runtime/core/inc/amd_kfd_driver.h
@@ -68,6 +68,8 @@ public:
 
   hsa_status_t Init() override;
   hsa_status_t QueryKernelModeDriver(core::DriverQuery query) override;
+  hsa_status_t Open() override;
+  hsa_status_t Close() override;
   hsa_status_t GetAgentProperties(core::Agent &agent) const override;
   hsa_status_t
   GetMemoryProperties(uint32_t node_id,

--- a/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
+++ b/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
@@ -142,6 +142,8 @@ public:
   std::unordered_map<uint32_t, void*>& GetHandleMappings();
   std::unordered_map<void*, uint32_t>& GetAddrMappings();
 
+  hsa_status_t Open() override;
+  hsa_status_t Close() override;
   hsa_status_t GetAgentProperties(core::Agent &agent) const override;
   hsa_status_t
   GetMemoryProperties(uint32_t node_id,

--- a/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
+++ b/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
@@ -129,14 +129,15 @@ inline uint32_t GetOperandCount(uint32_t arg_count) {
 class XdnaDriver final : public core::Driver {
 public:
   XdnaDriver(std::string devnode_name);
-  ~XdnaDriver();
+  ~XdnaDriver() = default;
 
-  static hsa_status_t DiscoverDriver();
+  static hsa_status_t DiscoverDriver(std::unique_ptr<core::Driver>& driver);
 
   /// @brief Returns the size of the dev heap in bytes.
   static uint64_t GetDevHeapByteSize();
 
   hsa_status_t Init() override;
+  hsa_status_t ShutDown() override;
   hsa_status_t QueryKernelModeDriver(core::DriverQuery query) override;
 
   std::unordered_map<uint32_t, void*>& GetHandleMappings();
@@ -144,6 +145,10 @@ public:
 
   hsa_status_t Open() override;
   hsa_status_t Close() override;
+  hsa_status_t GetSystemProperties(HsaSystemProperties& sys_props) const override;
+  hsa_status_t GetNodeProperties(HsaNodeProperties& node_props, uint32_t node_id) const override;
+  hsa_status_t GetEdgeProperties(std::vector<HsaIoLinkProperties>& io_link_props,
+                                 uint32_t node_id) const override;
   hsa_status_t GetAgentProperties(core::Agent &agent) const override;
   hsa_status_t
   GetMemoryProperties(uint32_t node_id,

--- a/runtime/hsa-runtime/core/inc/driver.h
+++ b/runtime/hsa-runtime/core/inc/driver.h
@@ -84,11 +84,11 @@ class Driver {
 
   /// @brief Open a connection to the driver using name_.
   /// @retval HSA_STATUS_SUCCESS if the driver was opened successfully.
-  hsa_status_t Open();
+  virtual hsa_status_t Open() = 0;
 
   /// @brief Close a connection to the open driver using fd_.
   /// @retval HSA_STATUS_SUCCESS if the driver was opened successfully.
-  hsa_status_t Close();
+  virtual hsa_status_t Close() = 0;
 
   /// @brief Get driver version information.
   /// @retval DriverVersionInfo containing the driver's version information.

--- a/runtime/hsa-runtime/core/inc/runtime.h
+++ b/runtime/hsa-runtime/core/inc/runtime.h
@@ -63,8 +63,7 @@
 #include "core/inc/hsa_ext_amd_impl.h"
 
 #include "core/inc/agent.h"
-#include "core/inc/amd_kfd_driver.h"
-#include "core/inc/amd_xdna_driver.h"
+#include "core/inc/driver.h"
 #include "core/inc/exceptions.h"
 #include "core/inc/interrupt_signal.h"
 #include "core/inc/memory_region.h"
@@ -159,7 +158,7 @@ class Runtime {
 
   /// @brief Insert agent into the driver list.
   /// @param [in] driver Unique pointer to the driver object.
-  void RegisterDriver(std::unique_ptr<Driver> &driver);
+  void RegisterDriver(std::unique_ptr<Driver> driver);
 
   /// @brief Delete all agent objects from ::agents_.
   void DestroyAgents();
@@ -493,6 +492,8 @@ class Runtime {
 
     return **driver;
   }
+
+  std::vector<std::unique_ptr<Driver>>& AgentDrivers() { return agent_drivers_; }
 
  protected:
   static void AsyncEventsLoop(void*);

--- a/runtime/hsa-runtime/core/runtime/amd_aie_aql_queue.cpp
+++ b/runtime/hsa-runtime/core/runtime/amd_aie_aql_queue.cpp
@@ -55,6 +55,7 @@
 
 #include <cstring>
 
+#include "core/inc/amd_xdna_driver.h"
 #include "core/inc/queue.h"
 #include "core/inc/runtime.h"
 #include "core/inc/signal.h"

--- a/runtime/hsa-runtime/core/runtime/amd_topology.cpp
+++ b/runtime/hsa-runtime/core/runtime/amd_topology.cpp
@@ -458,9 +458,6 @@ bool Unload() {
 
   hsaKmtReleaseSystemProperties();
 
-  // Close connection to kernel driver.
-  hsaKmtCloseKFD();
-
   return true;
 }
 }  // namespace amd

--- a/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -255,7 +255,7 @@ void Runtime::RegisterAgent(Agent* agent, bool Enabled) {
 }
 
 // Register driver.
-void Runtime::RegisterDriver(std::unique_ptr<Driver> &driver) {
+void Runtime::RegisterDriver(std::unique_ptr<Driver> driver) {
   agent_drivers_.push_back(std::move(driver));
 }
 
@@ -283,10 +283,6 @@ void Runtime::DestroyAgents() {
 }
 
 void Runtime::DestroyDrivers() {
-  for (auto &d : agent_drivers_) {
-    d->Close();
-  }
-
   agent_drivers_.clear();
 }
 
@@ -2161,9 +2157,9 @@ void Runtime::Unload() {
 
   CloseTools();
 
-  DestroyDrivers();
-
   AMD::Unload();
+
+  DestroyDrivers();
 }
 
 void Runtime::LoadExtensions() {

--- a/runtime/hsa-runtime/inc/hsa_ext_amd.h
+++ b/runtime/hsa-runtime/inc/hsa_ext_amd.h
@@ -70,22 +70,18 @@ extern "C" {
  */
 
 /**
- * @brief Macro to set a flag within uint8_t[8] types
- * types
+ * @brief Macro to set a flag within uint8_t[8] types.
  */
-static __inline__ __attribute__((always_inline)) void hsa_flag_set64(uint8_t* value,
-                                                                       uint32_t bit) {
+static inline void hsa_flag_set64(uint8_t* value, uint32_t bit) {
   unsigned int index = bit / 8;
   unsigned int subBit = bit % 8;
   (((uint8_t*)value)[index]) |= (1 << subBit);
 }
 
 /**
- * @brief Macro to use to determine that a flag is set when querying flags within uint8_t[8]
- * types
+ * @brief Macro to determine whether a flag is set within uint8_t[8] types.
  */
-static __inline__ __attribute__((always_inline)) bool hsa_flag_isset64(uint8_t* value,
-                                                                       uint32_t bit) {
+static inline bool hsa_flag_isset64(uint8_t* value, uint32_t bit) {
   unsigned int index = bit / 8;
   unsigned int subBit = bit % 8;
   return ((uint8_t*)value)[index] & (1 << subBit);
@@ -130,7 +126,7 @@ typedef struct hsa_amd_packet_header_s {
   uint16_t header;
 
   /**
-   *Format of the vendor specific packet.
+   * Format of the vendor specific packet.
    */
   hsa_amd_packet_type8_t AmdFormat;
 


### PR DESCRIPTION
rocprofiler-sdk uses this header, so reverting until we find a solution to that.

This reverts commit ea66d582d57a9dfded5970bec3b9591fd72153a7.