### PR TITLE
rocr: set underlying type of hsa_region

### DIFF
--- a/runtime/hsa-runtime/inc/hsa.h
+++ b/runtime/hsa-runtime/inc/hsa.h
@@ -3269,7 +3269,12 @@ typedef enum {
 /**
  * @brief Attributes of a memory region.
  */
+
+#ifdef __cplusplus
+typedef enum : int {
+#else
 typedef enum {
+#endif
   /**
    * Segment where memory in the region can be used. The type of this
    * attribute is ::hsa_region_segment_t.

--- a/runtime/hsa-runtime/inc/hsa_ext_amd.h
+++ b/runtime/hsa-runtime/inc/hsa_ext_amd.h
@@ -771,7 +771,11 @@ typedef struct hsa_amd_hdp_flush_s {
 /**
  * @brief Region attributes.
  */
+#ifdef __cplusplus
+typedef enum hsa_amd_region_info_s : int {
+#else
 typedef enum hsa_amd_region_info_s {
+#endif
   /**
    * Determine if host can access the region. The type of this attribute
    * is bool.


### PR DESCRIPTION
Set underlying type of hsa_region_info_t, hsa_amd_region_info_t to int.

Change-Id: Ibf97a025eec6176d8e28af8009e9bd6795ca061f