### PR TITLE
Change grid dimensions

### DIFF
--- a/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -1358,7 +1358,7 @@ hsa_status_t GpuAgent::GetInfo(hsa_agent_info_t attribute, void* value) const {
       *((uint32_t*)value) = 1024;
       break;
     case HSA_AGENT_INFO_GRID_MAX_DIM: {
-      const hsa_dim3_t grid_size = {UINT32_MAX, UINT32_MAX, UINT32_MAX};
+      const hsa_dim3_t grid_size = {LONG_MAX, UINT_MAX, UINT_MAX};
       std::memcpy(value, &grid_size, sizeof(hsa_dim3_t));
     } break;
     case HSA_AGENT_INFO_GRID_MAX_SIZE:


### PR DESCRIPTION
This change updates the max grid dimensions from 2^{32} - 1 for x, y, z, to 2^{31} - 1, 2^{16} - 1, 2^{16} - 1, in line with [hipGetDeviceProperties](https://github.com/ROCm/clr/blob/e9b33af45a473a2c7e690f1e0473d9631d952f24/hipamd/src/hip_device.cpp#L484) and CUDA.