### PR TITLE
fix license include path

### DIFF
--- a/runtime/docs/license.rst
+++ b/runtime/docs/license.rst
@@ -1,4 +1,4 @@
 License
 =======
 
-.. include:: ../LICENSE.txt
+.. include:: ../../LICENSE.txt


### PR DESCRIPTION
Add relative path correction for LICENSE.txt reference for docs/6.3.2