### PR TITLE
kfdtest: call non-deprecated overload of Target::createMCObjectStreamer()

### DIFF
--- a/libhsakmt/tests/kfdtest/src/Assemble.cpp
+++ b/libhsakmt/tests/kfdtest/src/Assemble.cpp
@@ -359,11 +359,18 @@ int Assembler::RunAssemble(const char* const AssemblySource) {
 	    return -1;
     }
 
+#if LLVM_VERSION_MAJOR < 19
     std::unique_ptr<MCStreamer> Streamer(TheTarget->createMCObjectStreamer(
         TheTriple, Ctx,
         std::unique_ptr<MCAsmBackend>(MAB), MAB->createObjectWriter(*OS),
         std::unique_ptr<MCCodeEmitter>(CE), *STI, MCOptions.MCRelaxAll,
         MCOptions.MCIncrementalLinkerCompatible, /*DWARFMustBeAtTheEnd*/ false));
+#else
+    std::unique_ptr<MCStreamer> Streamer(TheTarget->createMCObjectStreamer(
+        TheTriple, Ctx,
+        std::unique_ptr<MCAsmBackend>(MAB), MAB->createObjectWriter(*OS),
+        std::unique_ptr<MCCodeEmitter>(CE), *STI));
+#endif
 
     std::unique_ptr<MCAsmParser> Parser(
             createMCAsmParser(SrcMgr, Ctx, *Streamer, *MAI));


### PR DESCRIPTION
Use the new overload of Target::createMCObjectStreamer() without the three trailing, unused bool arguments. The existing overload with the three bool arguments was deprecated in LLVM 19 and removed in main.

Link: https://github.com/llvm/llvm-project/commit/d69eb7b7ffb33d0be716759a38a235868671705d
Link: https://github.com/llvm/llvm-project/commit/f1422a86c4a812a7ccd744082741841e596ccea0
Link: https://github.com/llvm/llvm-project/commit/f2ff298867d7733122e32eead5a8c524b09dfdb1