### PR TITLE
[hsa-runtime] Add missing cstdint include

### DIFF
--- a/runtime/hsa-runtime/core/inc/amd_elf_image.hpp
+++ b/runtime/hsa-runtime/core/inc/amd_elf_image.hpp
@@ -47,6 +47,7 @@
 #include <sstream>
 #include <vector>
 #include <memory>
+#include <cstdint>
 
 namespace rocr {
 namespace amd {


### PR DESCRIPTION
This fixes the build with gcc 15 which is now released in major
distributions such as Fedora and Arch Linux.

Signed-off-by: Christian Heusel <christian@heusel.eu>
