### PR TITLE
[cmake] - Update search for LibElf

### DIFF
--- a/runtime/hsa-runtime/CMakeLists.txt
+++ b/runtime/hsa-runtime/CMakeLists.txt
@@ -85,6 +85,11 @@ endif() # if (ROCM_CCACHE_BUILD)
 find_package(PkgConfig)
 find_package(LibElf REQUIRED)
 
+find_package(LibElf CONFIG)
+if(NOT LibElf_FOUND)
+  find_package(LibElf REQUIRED)
+endif()
+
 pkg_check_modules(drm REQUIRED IMPORTED_TARGET libdrm)
 
 ## Create the rocr target.


### PR DESCRIPTION
There is an issue with TheRock build currently. They have a local source build of elfutils they want to use instead of a system package. Currently, rocr uses it's own FindLibElf.cmake module and this is inhibiting the build from finding the libelf config built by TheRock.

Now we will first search in config mode and fallback to module mode if nothing is found.