### PR TITLE
ROCR/Driver: add global driver for the hsakmt APIs can not index agent

### DIFF
--- a/runtime/hsa-runtime/core/driver/driver.cpp
+++ b/runtime/hsa-runtime/core/driver/driver.cpp
@@ -51,5 +51,7 @@ Driver::Driver(DriverType kernel_driver_type, std::string devnode_name)
     : kernel_driver_type_(std::move(kernel_driver_type)),
       devnode_name_(std::move(devnode_name)) {}
 
+Driver::DriverFunctionTable Driver::function_table_;
+
 } // namespace core
 } // namespace rocr

--- a/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
+++ b/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
@@ -118,6 +118,8 @@ hsa_status_t KfdDriver::Init() {
   function_table_.set_event = HSAKMT_CALL(hsaKmtSetEvent);
   function_table_.wait_event_ext = HSAKMT_CALL(hsaKmtWaitOnEvent_Ext);
   function_table_.wait_events_ext = HSAKMT_CALL(hsaKmtWaitOnMultipleEvents_Ext);
+  function_table_.alloc_mem_align = HSAKMT_CALL(hsaKmtAllocMemoryAlign);
+  function_table_.free_memory = HSAKMT_CALL(hsaKmtFreeMemory);
 
   return HSA_STATUS_SUCCESS;
 }

--- a/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
+++ b/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
@@ -120,6 +120,11 @@ hsa_status_t KfdDriver::Init() {
   function_table_.wait_events_ext = HSAKMT_CALL(hsaKmtWaitOnMultipleEvents_Ext);
   function_table_.alloc_mem_align = HSAKMT_CALL(hsaKmtAllocMemoryAlign);
   function_table_.free_memory = HSAKMT_CALL(hsaKmtFreeMemory);
+  function_table_.unmap_mem = HSAKMT_CALL(hsaKmtUnmapMemoryToGPU);
+  function_table_.deregister_mem = HSAKMT_CALL(hsaKmtDeregisterMemory);
+  function_table_.register_graphics_handle = HSAKMT_CALL(hsaKmtRegisterGraphicsHandleToNodes);
+  function_table_.register_graphics_handle_ext =
+      HSAKMT_CALL(hsaKmtRegisterGraphicsHandleToNodesExt);
 
   return HSA_STATUS_SUCCESS;
 }

--- a/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
+++ b/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
@@ -127,6 +127,8 @@ hsa_status_t KfdDriver::Init() {
       HSAKMT_CALL(hsaKmtRegisterGraphicsHandleToNodesExt);
   function_table_.query_pointer_info = HSAKMT_CALL(hsaKmtQueryPointerInfo);
   function_table_.set_memory_user_data = HSAKMT_CALL(hsaKmtSetMemoryUserData);
+  function_table_.svm_set_attr = HSAKMT_CALL(hsaKmtSVMSetAttr);
+  function_table_.svm_get_attr = HSAKMT_CALL(hsaKmtSVMGetAttr);
 
   return HSA_STATUS_SUCCESS;
 }

--- a/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
+++ b/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
@@ -125,6 +125,8 @@ hsa_status_t KfdDriver::Init() {
   function_table_.register_graphics_handle = HSAKMT_CALL(hsaKmtRegisterGraphicsHandleToNodes);
   function_table_.register_graphics_handle_ext =
       HSAKMT_CALL(hsaKmtRegisterGraphicsHandleToNodesExt);
+  function_table_.query_pointer_info = HSAKMT_CALL(hsaKmtQueryPointerInfo);
+  function_table_.set_memory_user_data = HSAKMT_CALL(hsaKmtSetMemoryUserData);
 
   return HSA_STATUS_SUCCESS;
 }

--- a/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
+++ b/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
@@ -113,6 +113,12 @@ hsa_status_t KfdDriver::Init() {
   bool xnack_mode = BindXnackMode();
   core::Runtime::runtime_singleton_->XnackEnabled(xnack_mode);
 
+  function_table_.create_event = HSAKMT_CALL(hsaKmtCreateEvent);
+  function_table_.destroy_event = HSAKMT_CALL(hsaKmtDestroyEvent);
+  function_table_.set_event = HSAKMT_CALL(hsaKmtSetEvent);
+  function_table_.wait_event_ext = HSAKMT_CALL(hsaKmtWaitOnEvent_Ext);
+  function_table_.wait_events_ext = HSAKMT_CALL(hsaKmtWaitOnMultipleEvents_Ext);
+
   return HSA_STATUS_SUCCESS;
 }
 

--- a/runtime/hsa-runtime/core/inc/driver.h
+++ b/runtime/hsa-runtime/core/inc/driver.h
@@ -533,6 +533,45 @@ public:
     return HSA_STATUS_SUCCESS;
   }
 
+  /// @brief Allocates memory aligned to a specified boundary. Normally used for CPU virtual address
+  /// reserve.
+  /// @param[in] node_id Node ID of the agent
+  /// @param[in] size Size of the memory to be allocated
+  /// @param[in] alignment Alignment of the memory to be allocated
+  /// @param[in] mem_flags Memory flags for the allocation
+  /// @param[out] mem Pointer to store the allocated memory address
+  /// @return HSA_STATUS_SUCCESS if the memory was successfully allocated, or an error code
+  static hsa_status_t VirtualAddressReserve(uint32_t node_id, uint64_t size, uint64_t alignment,
+                                            HsaMemFlags mem_flags, void** mem) {
+    auto alloc_mem_align = function_table_.alloc_mem_align;
+    if (alloc_mem_align == nullptr) {
+      return HSA_STATUS_ERROR_NOT_INITIALIZED;
+    }
+
+    if (alloc_mem_align(node_id, size, alignment, mem_flags, mem) != HSAKMT_STATUS_SUCCESS) {
+      return HSA_STATUS_ERROR;
+    }
+    return HSA_STATUS_SUCCESS;
+  }
+
+  /// @brief Frees memory allocated by the driver. Normally used for free a reserved CPU virtual
+  /// address.
+  /// @param[in] mem Pointer to the memory to be freed
+  /// @param[in] size Size of the memory to be freed
+  /// @return HSA_STATUS_SUCCESS if the memory was successfully freed, or an error code
+  static hsa_status_t VirtualAddressFree(void* mem, size_t size) {
+    auto free_memory = function_table_.free_memory;
+    if (free_memory == nullptr) {
+      return HSA_STATUS_ERROR_NOT_INITIALIZED;
+    }
+
+    if (free_memory(mem, size) != HSAKMT_STATUS_SUCCESS) {
+      return HSA_STATUS_ERROR;
+    }
+
+    return HSA_STATUS_SUCCESS;
+  }
+
  protected:
   HsaVersionInfo version_{std::numeric_limits<uint32_t>::max(),
                           std::numeric_limits<uint32_t>::max()};
@@ -545,6 +584,8 @@ public:
   using set_event_fn = HSAKMT_STATUS (*)(HsaEvent*);
   using wait_event_ext_fn = HSAKMT_STATUS (*)(HsaEvent*, uint32_t, uint64_t*);
   using wait_events_ext_fn = HSAKMT_STATUS (*)(HsaEvent*[], uint32_t, bool, uint32_t, uint64_t*);
+  using alloc_mem_align_fn = HSAKMT_STATUS (*)(uint32_t, uint64_t, uint64_t, HsaMemFlags, void**);
+  using free_memory_fn = HSAKMT_STATUS (*)(void*, size_t);
 
   struct DriverFunctionTable {
     create_event_fn create_event;
@@ -552,6 +593,8 @@ public:
     set_event_fn set_event;
     wait_event_ext_fn wait_event_ext;
     wait_events_ext_fn wait_events_ext;
+    alloc_mem_align_fn alloc_mem_align;
+    free_memory_fn free_memory;
   };
 
   static DriverFunctionTable function_table_;

--- a/runtime/hsa-runtime/core/inc/driver.h
+++ b/runtime/hsa-runtime/core/inc/driver.h
@@ -683,6 +683,46 @@ public:
     return HSA_STATUS_SUCCESS;
   }
 
+  /// @brief Sets SVM attributes for a pointer.
+  /// @param[in] ptr Pointer to set SVM attributes for.
+  /// @param[in] size Size of the memory to set SVM attributes for.
+  /// @param[in] nattr Number of attributes to set.
+  /// @param[in] attrs Array of attributes to set.
+  /// @return HSA_STATUS_SUCCESS if the SVM attributes were successfully set, or an error code.
+  static hsa_status_t SVMSetAttr(void* ptr, uint64_t size, unsigned int nattr,
+                                 HSA_SVM_ATTRIBUTE* attrs) {
+    auto svm_set_attr = function_table_.svm_set_attr;
+    if (svm_set_attr == nullptr) {
+      return HSA_STATUS_ERROR_NOT_INITIALIZED;
+    }
+
+    if (svm_set_attr(ptr, size, nattr, attrs) != HSAKMT_STATUS_SUCCESS) {
+      return HSA_STATUS_ERROR;
+    }
+
+    return HSA_STATUS_SUCCESS;
+  }
+
+  /// @brief Gets SVM attributes for a pointer.
+  /// @param[in] ptr Pointer to get SVM attributes for.
+  /// @param[in] size Size of the memory to get SVM attributes for.
+  /// @param[in] nattr Number of attributes to get.
+  /// @param[out] attrs Array of attributes to get.
+  /// @return HSA_STATUS_SUCCESS if the SVM attributes were successfully got, or an error code.
+  static hsa_status_t SVMGetAttr(void* ptr, uint64_t size, unsigned int nattr,
+                                 HSA_SVM_ATTRIBUTE* attrs) {
+    auto svm_get_attr = function_table_.svm_get_attr;
+    if (svm_get_attr == nullptr) {
+      return HSA_STATUS_ERROR_NOT_INITIALIZED;
+    }
+
+    if (svm_get_attr(ptr, size, nattr, attrs) != HSAKMT_STATUS_SUCCESS) {
+      return HSA_STATUS_ERROR;
+    }
+
+    return HSA_STATUS_SUCCESS;
+  }
+
  protected:
   HsaVersionInfo version_{std::numeric_limits<uint32_t>::max(),
                           std::numeric_limits<uint32_t>::max()};
@@ -706,6 +746,8 @@ public:
                                                             HSA_REGISTER_MEM_FLAGS);
   using query_pointer_info_fn = HSAKMT_STATUS (*)(const void*, HsaPointerInfo*);
   using set_memory_user_data_fn = HSAKMT_STATUS (*)(const void*, void*);
+  using svm_set_attr_fn = HSAKMT_STATUS (*)(void*, uint64_t, unsigned int, HSA_SVM_ATTRIBUTE*);
+  using svm_get_attr_fn = HSAKMT_STATUS (*)(void*, uint64_t, unsigned int, HSA_SVM_ATTRIBUTE*);
 
   struct DriverFunctionTable {
     create_event_fn create_event;
@@ -721,6 +763,8 @@ public:
     register_graphics_handle_ext_fn register_graphics_handle_ext;
     query_pointer_info_fn query_pointer_info;
     set_memory_user_data_fn set_memory_user_data;
+    svm_set_attr_fn svm_set_attr;
+    svm_get_attr_fn svm_get_attr;
   };
 
   static DriverFunctionTable function_table_;

--- a/runtime/hsa-runtime/core/inc/driver.h
+++ b/runtime/hsa-runtime/core/inc/driver.h
@@ -440,12 +440,121 @@ public:
   /// Unique identifier for supported kernel-mode drivers.
   const DriverType kernel_driver_type_;
 
-protected:
- HsaVersionInfo version_{std::numeric_limits<uint32_t>::max(),
-                         std::numeric_limits<uint32_t>::max()};
+  /// @brief Creates an operating system event associated with a HSA event ID
+  /// @param[in] event_desc Pointer to the event descriptor that describes the event
+  /// @param[in] manual_reset if true, the event is manually reset; otherwise, it is automatically
+  /// reset
+  /// @param[in] IsSignaled if true, the event is initially signaled
+  /// @param[out] event pointer to the created HsaEvent object
+  /// @return HSA_STATUS_SUCCESS if the event was successfully created, or an error code
+  static hsa_status_t CreateEvent(HsaEventDescriptor* event_desc, bool manual_reset,
+                                  bool IsSignaled, HsaEvent** event) {
+    auto create_event = function_table_.create_event;
+    if (create_event == nullptr) {
+      return HSA_STATUS_ERROR_NOT_INITIALIZED;
+    }
 
- const std::string devnode_name_;
- int fd_ = -1;
+    if (create_event(event_desc, manual_reset, IsSignaled, event) != HSAKMT_STATUS_SUCCESS) {
+      return HSA_STATUS_ERROR;
+    }
+
+    return HSA_STATUS_SUCCESS;
+  }
+
+  /// @brief Destroys an operating system event associated with a HSA event ID
+  /// @param[in] event pointer to the HsaEvent object to be destroyed
+  /// @return HSA_STATUS_SUCCESS if the event was successfully destroyed, or an error code
+  static hsa_status_t DestroyEvent(HsaEvent* event) {
+    auto destroy_event = function_table_.destroy_event;
+    if (destroy_event == nullptr) {
+      return HSA_STATUS_ERROR_NOT_INITIALIZED;
+    }
+
+    if (destroy_event(event) != HSAKMT_STATUS_SUCCESS) {
+      return HSA_STATUS_ERROR;
+    }
+
+    return HSA_STATUS_SUCCESS;
+  }
+
+  /// @brief Sets the specified event object to the signaled state
+  /// @param[in] event pointer to the HsaEvent object to be set
+  /// @return HSA_STATUS_SUCCESS if the event was successfully set, or an error code
+  static hsa_status_t SetEvent(HsaEvent* event) {
+    auto set_event = function_table_.set_event;
+    if (set_event == nullptr) {
+      return HSA_STATUS_ERROR_NOT_INITIALIZED;
+    }
+
+    if (set_event(event) != HSAKMT_STATUS_SUCCESS) {
+      return HSA_STATUS_ERROR;
+    }
+
+    return HSA_STATUS_SUCCESS;
+  }
+
+  /// @brief Checks the current state of the event object. If the object's state is
+  /// signaled, the function returns immediately.
+  /// @param[in] event pointer to the HsaEvent object to be queried
+  /// @param[in] milliseconds time in milliseconds to wait for the event to be signaled
+  /// @param[out] event_age pointer to a variable that will hold the event age
+  /// @return HSA_STATUS_SUCCESS if the event was successfully queried, or an error code
+  static hsa_status_t WaitEventExt(HsaEvent* event, uint32_t milliseconds, uint64_t* event_age) {
+    auto wait_event_ext = function_table_.wait_event_ext;
+    if (wait_event_ext == nullptr) {
+      return HSA_STATUS_ERROR_NOT_INITIALIZED;
+    }
+
+    if (wait_event_ext(event, milliseconds, event_age) != HSAKMT_STATUS_SUCCESS) {
+      return HSA_STATUS_ERROR;
+    }
+
+    return HSA_STATUS_SUCCESS;
+  }
+
+  /// @brief Checks the current state of multiple event objects.
+  /// @param[in] events array of pointers to HsaEvent objects to be queried
+  /// @param[in] num_events number of events in the array
+  /// @param[in] wait_on_all if true, the function waits for all events to be signaled;
+  /// @param[in] milliseconds time in milliseconds to wait for the events to be signaled
+  /// @param[out] event_age pointer to an array that will hold the event ages
+  /// @return
+  static hsa_status_t WaitEventsExt(HsaEvent* events[], uint32_t num_events, bool wait_on_all,
+                                    uint32_t milliseconds, uint64_t* event_age) {
+    auto wait_events_ext = function_table_.wait_events_ext;
+    if (wait_events_ext == nullptr) {
+      return HSA_STATUS_ERROR_NOT_INITIALIZED;
+    }
+
+    if (wait_events_ext(events, num_events, wait_on_all, milliseconds, event_age) !=
+        HSAKMT_STATUS_SUCCESS) {
+      return HSA_STATUS_ERROR;
+    }
+    return HSA_STATUS_SUCCESS;
+  }
+
+ protected:
+  HsaVersionInfo version_{std::numeric_limits<uint32_t>::max(),
+                          std::numeric_limits<uint32_t>::max()};
+
+  const std::string devnode_name_;
+  int fd_ = -1;
+
+  using create_event_fn = HSAKMT_STATUS (*)(HsaEventDescriptor*, bool, bool, HsaEvent**);
+  using destroy_event_fn = HSAKMT_STATUS (*)(HsaEvent*);
+  using set_event_fn = HSAKMT_STATUS (*)(HsaEvent*);
+  using wait_event_ext_fn = HSAKMT_STATUS (*)(HsaEvent*, uint32_t, uint64_t*);
+  using wait_events_ext_fn = HSAKMT_STATUS (*)(HsaEvent*[], uint32_t, bool, uint32_t, uint64_t*);
+
+  struct DriverFunctionTable {
+    create_event_fn create_event;
+    destroy_event_fn destroy_event;
+    set_event_fn set_event;
+    wait_event_ext_fn wait_event_ext;
+    wait_events_ext_fn wait_events_ext;
+  };
+
+  static DriverFunctionTable function_table_;
 };
 
 } // namespace core

--- a/runtime/hsa-runtime/core/inc/driver.h
+++ b/runtime/hsa-runtime/core/inc/driver.h
@@ -572,6 +572,83 @@ public:
     return HSA_STATUS_SUCCESS;
   }
 
+  /// @brief Unmaps the memory associated with the InterOP/IPC handle.
+  /// @param[in] mem Pointer to the memory to be unmapped.
+  /// @return HSA_STATUS_SUCCESS if the memory was successfully unmapped, or an error code.
+  static hsa_status_t ShareableMemoryUnmap(void* mem) {
+    auto unmap_mem = function_table_.unmap_mem;
+    if (unmap_mem == nullptr) {
+      return HSA_STATUS_ERROR_NOT_INITIALIZED;
+    }
+
+    if (unmap_mem(mem) != HSAKMT_STATUS_SUCCESS) {
+      return HSA_STATUS_ERROR;
+    }
+
+    return HSA_STATUS_SUCCESS;
+  }
+
+  /// @brief Deregisters the memory associated with the InterOP/IPC handle.
+  /// @param[in] mem Pointer to the memory to be deregistered.
+  /// @return HSA_STATUS_SUCCESS if the memory was successfully deregistered, or an error code.
+  static hsa_status_t ShareableMemoryDeregister(void* mem) {
+    auto deregister_mem = function_table_.deregister_mem;
+    if (deregister_mem == nullptr) {
+      return HSA_STATUS_ERROR_NOT_INITIALIZED;
+    }
+
+    if (deregister_mem(mem) != HSAKMT_STATUS_SUCCESS) {
+      return HSA_STATUS_ERROR;
+    }
+
+    return HSA_STATUS_SUCCESS;
+  }
+
+  /// @brief Registers a graphics handle.
+  /// @param[in] handle Handle to the graphics resource.
+  /// @param[in] info Pointer to the graphics resource info.
+  /// @param[in] num_nodes Number of nodes to register the graphics resource on.
+  /// @param[in] nodes Array of node IDs to register the graphics resource on.
+  /// @return HSA_STATUS_SUCCESS if the graphics handle was successfully registered, or an error
+  /// code.
+  static hsa_status_t RegisterGraphicsHandle(uint64_t handle, HsaGraphicsResourceInfo* info,
+                                             uint64_t num_nodes, uint32_t* nodes) {
+    auto register_graphics_handle = function_table_.register_graphics_handle;
+    if (register_graphics_handle == nullptr) {
+      return HSA_STATUS_ERROR_NOT_INITIALIZED;
+    }
+
+    if (register_graphics_handle(handle, info, num_nodes, nodes) != HSAKMT_STATUS_SUCCESS) {
+      return HSA_STATUS_ERROR;
+    }
+
+    return HSA_STATUS_SUCCESS;
+  }
+
+  /// @brief Registers a graphics handle with additional flags.
+  /// @param[in] handle Handle to the graphics resource.
+  /// @param[in] info Pointer to the graphics resource info.
+  /// @param[in] num_nodes Number of nodes to register the graphics resource on.
+  /// @param[in] nodes Array of node IDs to register the graphics resource on.
+  /// @param[in] flags Flags for the graphics resource.
+  /// @return HSA_STATUS_SUCCESS if the graphics handle was successfully registered, or an error
+  /// code.
+  static hsa_status_t RegisterGraphicsHandleExt(uint64_t handle, HsaGraphicsResourceInfo* info,
+                                                uint64_t num_nodes, uint32_t* nodes,
+                                                HSA_REGISTER_MEM_FLAGS flags) {
+    auto register_graphics_handle_ext = function_table_.register_graphics_handle_ext;
+    if (register_graphics_handle_ext == nullptr) {
+      return HSA_STATUS_ERROR_NOT_INITIALIZED;
+    }
+
+    if (register_graphics_handle_ext(handle, info, num_nodes, nodes, flags) !=
+        HSAKMT_STATUS_SUCCESS) {
+      return HSA_STATUS_ERROR;
+    }
+
+    return HSA_STATUS_SUCCESS;
+  }
+
  protected:
   HsaVersionInfo version_{std::numeric_limits<uint32_t>::max(),
                           std::numeric_limits<uint32_t>::max()};
@@ -586,6 +663,13 @@ public:
   using wait_events_ext_fn = HSAKMT_STATUS (*)(HsaEvent*[], uint32_t, bool, uint32_t, uint64_t*);
   using alloc_mem_align_fn = HSAKMT_STATUS (*)(uint32_t, uint64_t, uint64_t, HsaMemFlags, void**);
   using free_memory_fn = HSAKMT_STATUS (*)(void*, size_t);
+  using unmap_mem_fn = HSAKMT_STATUS (*)(void*);
+  using deregister_mem_fn = HSAKMT_STATUS (*)(void*);
+  using register_graphics_handle_fn = HSAKMT_STATUS (*)(uint64_t, HsaGraphicsResourceInfo*,
+                                                        uint64_t, uint32_t*);
+  using register_graphics_handle_ext_fn = HSAKMT_STATUS (*)(uint64_t, HsaGraphicsResourceInfo*,
+                                                            uint64_t, uint32_t*,
+                                                            HSA_REGISTER_MEM_FLAGS);
 
   struct DriverFunctionTable {
     create_event_fn create_event;
@@ -595,6 +679,10 @@ public:
     wait_events_ext_fn wait_events_ext;
     alloc_mem_align_fn alloc_mem_align;
     free_memory_fn free_memory;
+    unmap_mem_fn unmap_mem;
+    deregister_mem_fn deregister_mem;
+    register_graphics_handle_fn register_graphics_handle;
+    register_graphics_handle_ext_fn register_graphics_handle_ext;
   };
 
   static DriverFunctionTable function_table_;

--- a/runtime/hsa-runtime/core/inc/driver.h
+++ b/runtime/hsa-runtime/core/inc/driver.h
@@ -649,6 +649,40 @@ public:
     return HSA_STATUS_SUCCESS;
   }
 
+  /// @brief Queries information about a pointer.
+  /// @param[in] ptr Pointer to query information about.
+  /// @param[out] info Pointer to the pointer info.
+  /// @return HSA_STATUS_SUCCESS if the pointer info was successfully queried, or an error code.
+  static hsa_status_t QueryPointerInfo(const void* ptr, HsaPointerInfo* info) {
+    auto query_pointer_info = function_table_.query_pointer_info;
+    if (query_pointer_info == nullptr) {
+      return HSA_STATUS_ERROR_NOT_INITIALIZED;
+    }
+
+    if (query_pointer_info(ptr, info) != HSAKMT_STATUS_SUCCESS) {
+      return HSA_STATUS_ERROR;
+    }
+
+    return HSA_STATUS_SUCCESS;
+  }
+
+  /// @brief Sets user data for a pointer.
+  /// @param[in] ptr Pointer to set user data for.
+  /// @param[in] user_data User data to set.
+  /// @return HSA_STATUS_SUCCESS if the user data was successfully set, or an error code.
+  static hsa_status_t SetMemoryUserData(const void* ptr, void* user_data) {
+    auto set_memory_user_data = function_table_.set_memory_user_data;
+    if (set_memory_user_data == nullptr) {
+      return HSA_STATUS_ERROR_NOT_INITIALIZED;
+    }
+
+    if (set_memory_user_data(ptr, user_data) != HSAKMT_STATUS_SUCCESS) {
+      return HSA_STATUS_ERROR;
+    }
+
+    return HSA_STATUS_SUCCESS;
+  }
+
  protected:
   HsaVersionInfo version_{std::numeric_limits<uint32_t>::max(),
                           std::numeric_limits<uint32_t>::max()};
@@ -670,6 +704,8 @@ public:
   using register_graphics_handle_ext_fn = HSAKMT_STATUS (*)(uint64_t, HsaGraphicsResourceInfo*,
                                                             uint64_t, uint32_t*,
                                                             HSA_REGISTER_MEM_FLAGS);
+  using query_pointer_info_fn = HSAKMT_STATUS (*)(const void*, HsaPointerInfo*);
+  using set_memory_user_data_fn = HSAKMT_STATUS (*)(const void*, void*);
 
   struct DriverFunctionTable {
     create_event_fn create_event;
@@ -683,6 +719,8 @@ public:
     deregister_mem_fn deregister_mem;
     register_graphics_handle_fn register_graphics_handle;
     register_graphics_handle_ext_fn register_graphics_handle_ext;
+    query_pointer_info_fn query_pointer_info;
+    set_memory_user_data_fn set_memory_user_data;
   };
 
   static DriverFunctionTable function_table_;

--- a/runtime/hsa-runtime/core/runtime/interrupt_signal.cpp
+++ b/runtime/hsa-runtime/core/runtime/interrupt_signal.cpp
@@ -76,8 +76,7 @@ HsaEvent* InterruptSignal::CreateEvent(HSA_EVENTTYPE type, bool manual_reset) {
   event_descriptor.NodeId = 0;
 
   HsaEvent* ret = NULL;
-  if (HSAKMT_STATUS_SUCCESS ==
-      HSAKMT_CALL(hsaKmtCreateEvent(&event_descriptor, manual_reset, false, &ret))) {
+  if (HSA_STATUS_SUCCESS == Driver::CreateEvent(&event_descriptor, manual_reset, false, &ret)) {
     if (type == HSA_EVENTTYPE_MEMORY) {
       memset(&ret->EventData.EventData.MemoryAccessFault.Failure, 0,
              sizeof(HsaAccessAttributeFailure));
@@ -89,7 +88,7 @@ HsaEvent* InterruptSignal::CreateEvent(HSA_EVENTTYPE type, bool manual_reset) {
   return ret;
 }
 
-void InterruptSignal::DestroyEvent(HsaEvent* evt) { HSAKMT_CALL(hsaKmtDestroyEvent(evt)); }
+void InterruptSignal::DestroyEvent(HsaEvent* evt) { Driver::DestroyEvent(evt); }
 
 InterruptSignal::InterruptSignal(hsa_signal_value_t initial_value, HsaEvent* use_event)
     : LocalSignal(initial_value, false), Signal(signal()) {
@@ -194,7 +193,7 @@ hsa_signal_value_t InterruptSignal::WaitRelaxed(hsa_signal_condition_t condition
       static_cast<uint32_t>(signal_abort_timeout ? signal_abort_timeout * 1000 : 0xFFFFFFFFUL)
     );
 
-    HSAKMT_CALL(hsaKmtWaitOnEvent_Ext(event_, wait_ms, &event_age));
+    Driver::WaitEventExt(event_, wait_ms, &event_age);
   }
 }
 

--- a/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -960,7 +960,7 @@ hsa_status_t Runtime::PtrInfo(const void* ptr, hsa_amd_pointer_info_t* info, voi
 
     // We don't care if this returns an error code.
     // The type will be HSA_EXT_POINTER_TYPE_UNKNOWN if so.
-    auto err = HSAKMT_CALL(hsaKmtQueryPointerInfo(ptr, &thunkInfo));
+    auto err = Driver::QueryPointerInfo(ptr, &thunkInfo);
     if (err != HSAKMT_STATUS_SUCCESS || thunkInfo.Type == HSA_POINTER_UNKNOWN) {
       retInfo.type = HSA_EXT_POINTER_TYPE_UNKNOWN;
       memcpy(info, &retInfo, retInfo.size);
@@ -1081,9 +1081,9 @@ hsa_status_t Runtime::SetPtrInfoData(const void* ptr, void* userptr) {
     }
   }
   // Cover entries not in the allocation map (graphics, lock,...)
-  if (HSAKMT_CALL(hsaKmtSetMemoryUserData(ptr, userptr)) == HSAKMT_STATUS_SUCCESS)
-    return HSA_STATUS_SUCCESS;
-  return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+  if (Driver::SetMemoryUserData(ptr, userptr) != HSA_STATUS_SUCCESS)
+    return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+  return HSA_STATUS_SUCCESS;
 }
 
 // Send the dmabuf_fd to from process via Unix socket
@@ -3734,7 +3734,7 @@ hsa_status_t Runtime::VMemoryImportShareableHandle(int dmabuf_fd,
   if (!region) return HSA_STATUS_ERROR_INVALID_ALLOCATION;
 
   HsaPointerInfo ptrInfo;
-  ret = HSAKMT_CALL(hsaKmtQueryPointerInfo(info.MemoryAddress, &ptrInfo));
+  ret = Driver::QueryPointerInfo(info.MemoryAddress, &ptrInfo);
   if (ret != HSA_STATUS_SUCCESS || ptrInfo.Type == HSA_POINTER_UNKNOWN)
     return HSA_STATUS_ERROR_INVALID_ALLOCATION;
 

--- a/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -3178,10 +3178,10 @@ hsa_status_t Runtime::VMemoryAddressReserve(void** va, size_t size, uint64_t add
   memFlags.ui32.FixedAddress = 1;
 
   /* Try to reserving the VA requested by user */
-  if (HSAKMT_CALL(hsaKmtAllocMemoryAlign(0, size, alignment, memFlags, &addr)) != HSAKMT_STATUS_SUCCESS) {
+  if (Driver::VirtualAddressReserve(0, size, alignment, memFlags, &addr) != HSA_STATUS_SUCCESS) {
     memFlags.ui32.FixedAddress = 0;
     /* Could not reserved VA requested, allocate alternate VA */
-    if (HSAKMT_CALL(hsaKmtAllocMemoryAlign(0, size, alignment, memFlags, &addr)) != HSAKMT_STATUS_SUCCESS)
+    if (Driver::VirtualAddressReserve(0, size, alignment, memFlags, &addr) != HSA_STATUS_SUCCESS)
       return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
   }
 
@@ -3204,7 +3204,7 @@ hsa_status_t Runtime::VMemoryAddressFree(void* va, size_t size) {
   if (it->second.use_count > 0) return HSA_STATUS_ERROR_RESOURCE_FREE;
 
   if (it->second.registered) {
-    if (HSAKMT_CALL(hsaKmtFreeMemory(it->second.os_addr, size)) != HSAKMT_STATUS_SUCCESS) return HSA_STATUS_ERROR;
+    if (Driver::VirtualAddressFree(it->second.os_addr, size) != HSA_STATUS_SUCCESS) return HSA_STATUS_ERROR;
   } else {
     if (munmap(it->second.os_addr, size)) return HSA_STATUS_ERROR;
   }

--- a/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -961,7 +961,7 @@ hsa_status_t Runtime::PtrInfo(const void* ptr, hsa_amd_pointer_info_t* info, voi
     // We don't care if this returns an error code.
     // The type will be HSA_EXT_POINTER_TYPE_UNKNOWN if so.
     auto err = Driver::QueryPointerInfo(ptr, &thunkInfo);
-    if (err != HSAKMT_STATUS_SUCCESS || thunkInfo.Type == HSA_POINTER_UNKNOWN) {
+    if (err != HSA_STATUS_SUCCESS || thunkInfo.Type == HSA_POINTER_UNKNOWN) {
       retInfo.type = HSA_EXT_POINTER_TYPE_UNKNOWN;
       memcpy(info, &retInfo, retInfo.size);
       return HSA_STATUS_SUCCESS;
@@ -2733,9 +2733,8 @@ hsa_status_t Runtime::SetSvmAttrib(void* ptr, size_t size,
   uint8_t* base = AlignDown((uint8_t*)ptr, 4096);
   uint8_t* end = AlignUp((uint8_t*)ptr + size, 4096);
   size_t len = end - base;
-  HSAKMT_STATUS error = HSAKMT_CALL(hsaKmtSVMSetAttr(base, len, attribs.size(), &attribs[0]));
-  if (error != HSAKMT_STATUS_SUCCESS)
-    throw AMD::hsa_exception(HSA_STATUS_ERROR, "hsaKmtSVMSetAttr failed.");
+  hsa_status_t error = Driver::SVMSetAttr(base, len, attribs.size(), &attribs[0]);
+  if (error != HSA_STATUS_SUCCESS) throw AMD::hsa_exception(HSA_STATUS_ERROR, "SVMSetAttr failed.");
 
   return HSA_STATUS_SUCCESS;
 }
@@ -2819,9 +2818,9 @@ hsa_status_t Runtime::GetSvmAttrib(void* ptr, size_t size,
   uint8_t* end = AlignUp((uint8_t*)ptr + size, 4096);
   size_t len = end - base;
   if (attribs.size() != 0) {
-    HSAKMT_STATUS error = HSAKMT_CALL(hsaKmtSVMGetAttr(base, len, attribs.size(), &attribs[0]));
-    if (error != HSAKMT_STATUS_SUCCESS)
-      throw AMD::hsa_exception(HSA_STATUS_ERROR, "hsaKmtSVMGetAttr failed.");
+    hsa_status_t error = Driver::SVMGetAttr(base, len, attribs.size(), &attribs[0]);
+    if (error != HSA_STATUS_SUCCESS)
+      throw AMD::hsa_exception(HSA_STATUS_ERROR, "SVMGetAttr failed.");
   }
 
   for (uint32_t i = 0; i < attribute_count; i++) {
@@ -3009,8 +3008,8 @@ hsa_status_t Runtime::SvmPrefetch(void* ptr, size_t size, hsa_agent_t agent,
     HSA_SVM_ATTRIBUTE attrib;
     attrib.type = HSA_SVM_ATTR_PREFETCH_LOC;
     attrib.value = op->node_id;
-    HSAKMT_STATUS error = HSAKMT_CALL(hsaKmtSVMSetAttr(op->base, op->size, 1, &attrib));
-    assert(error == HSAKMT_STATUS_SUCCESS && "KFD Prefetch failed.");
+    hsa_status_t error = Driver::SVMSetAttr(op->base, op->size, 1, &attrib);
+    assert(error == HSA_STATUS_SUCCESS && "KFD Prefetch failed.");
 
     removePrefetchRanges(op);
 
@@ -3078,9 +3077,9 @@ Agent* Runtime::GetSVMPrefetchAgent(void* ptr, size_t size) {
   HSA_SVM_ATTRIBUTE attrib;
   attrib.type = HSA_SVM_ATTR_PREFETCH_LOC;
   for (auto& range : holes) {
-    HSAKMT_STATUS error =
-        HSAKMT_CALL(hsaKmtSVMGetAttr(reinterpret_cast<void*>(range.first), range.second, 1, &attrib));
-    assert(error == HSAKMT_STATUS_SUCCESS && "KFD prefetch query failed.");
+    hsa_status_t error =
+        Driver::SVMGetAttr(reinterpret_cast<void*>(range.first), range.second, 1, &attrib);
+    assert(error == HSA_STATUS_SUCCESS && "KFD prefetch query failed.");
 
     if (attrib.value == -1) return nullptr;
     if (prefetch_node == -2) prefetch_node = attrib.value;

--- a/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -872,6 +872,7 @@ hsa_status_t Runtime::InteropMap(uint32_t num_agents, Agent** agents,
 
   HSAuint32 short_nodes[tinyArraySize];
   HSAuint32* nodes = short_nodes;
+  core::Driver* driver = nullptr;
   if (num_agents > tinyArraySize) {
     nodes = new HSAuint32[num_agents];
     if (nodes == NULL) return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
@@ -880,25 +881,27 @@ hsa_status_t Runtime::InteropMap(uint32_t num_agents, Agent** agents,
     if (num_agents > tinyArraySize) delete[] nodes;
   });
 
+  if (Runtime::IsDifferentDriver(*agents, num_agents)) return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+  driver = &agents[0]->driver();
+
   for (uint32_t i = 0; i < num_agents; i++)
     agents[i]->GetInfo((hsa_agent_info_t)HSA_AMD_AGENT_INFO_DRIVER_NODE_ID,
                        &nodes[i]);
 
-  if (HSAKMT_CALL(hsaKmtRegisterGraphicsHandleToNodes(interop_handle, &info, num_agents,
-                                          nodes)) != HSAKMT_STATUS_SUCCESS)
+  if (Driver::RegisterGraphicsHandle(interop_handle, &info, num_agents, nodes) !=
+      HSA_STATUS_SUCCESS)
     return HSA_STATUS_ERROR;
 
   HSAuint64 altAddress;
   HsaMemMapFlags map_flags;
   map_flags.Value = 0;
   map_flags.ui32.PageSize = HSA_PAGE_SIZE_64KB;
-  if (HSAKMT_CALL(hsaKmtMapMemoryToGPUNodes(info.MemoryAddress, info.SizeInBytes,
-                                &altAddress, map_flags, num_agents,
-                                nodes)) != HSAKMT_STATUS_SUCCESS) {
+  if (driver->MakeMemoryResident(info.MemoryAddress, info.SizeInBytes, &altAddress, &map_flags,
+                                 num_agents, nodes) != HSA_STATUS_SUCCESS) {
     map_flags.ui32.PageSize = HSA_PAGE_SIZE_4KB;
-    if (HSAKMT_CALL(hsaKmtMapMemoryToGPUNodes(info.MemoryAddress, info.SizeInBytes, &altAddress, map_flags,
-                                  num_agents, nodes)) != HSAKMT_STATUS_SUCCESS) {
-      HSAKMT_CALL(hsaKmtDeregisterMemory(info.MemoryAddress));
+    if (driver->MakeMemoryResident(info.MemoryAddress, info.SizeInBytes, &altAddress, &map_flags,
+                                   num_agents, nodes) != HSA_STATUS_SUCCESS) {
+      driver->DeregisterMemory(info.MemoryAddress);
       return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
     }
   }
@@ -917,9 +920,9 @@ hsa_status_t Runtime::InteropMap(uint32_t num_agents, Agent** agents,
 }
 
 hsa_status_t Runtime::InteropUnmap(void* ptr) {
-  if(HSAKMT_CALL(hsaKmtUnmapMemoryToGPU(ptr))!=HSAKMT_STATUS_SUCCESS)
+  if (Driver::ShareableMemoryUnmap(ptr) != HSA_STATUS_SUCCESS)
     return HSA_STATUS_ERROR_INVALID_ARGUMENT;
-  if(HSAKMT_CALL(hsaKmtDeregisterMemory(ptr))!=HSAKMT_STATUS_SUCCESS)
+  if (Driver::ShareableMemoryDeregister(ptr) != HSA_STATUS_SUCCESS)
     return HSA_STATUS_ERROR_INVALID_ARGUMENT;
   return HSA_STATUS_SUCCESS;
 }
@@ -1318,6 +1321,12 @@ int Runtime::IPCClientImport(uint32_t conn_handle, uint64_t dmabuf_fd_handle,
     assert(socket_fd > -1 && "DMA buffer could not be imported for IPC!");
     if (socket_fd == -1) return -1;
 
+    // if (core::Runtime::runtime_singleton_->IsDifferentDriver(nodes, numNodes)) {
+    //   close(socket_fd);
+    //   return -1;
+    // }
+    core::Driver* driver = &agents_by_node_[nodes[0]][0]->driver();
+
     // Set 10 second timeout for ReceiveDmaBufFd
     struct timeval tv;
     tv.tv_sec = 10;
@@ -1359,12 +1368,12 @@ int Runtime::IPCClientImport(uint32_t conn_handle, uint64_t dmabuf_fd_handle,
     HsaGraphicsResourceInfo info;
     HSA_REGISTER_MEM_FLAGS regFlags;
     regFlags.ui32.requiresVAddr = !!res ? 0 : 1;
-    int err = HSAKMT_CALL(hsaKmtRegisterGraphicsHandleToNodesExt(dmabuf_fd, &info, numNodes, nodes, regFlags));
-    if (err == HSAKMT_STATUS_SUCCESS) {
+    int err = Driver::RegisterGraphicsHandleExt(dmabuf_fd, &info, numNodes, nodes, regFlags);
+    if (err == HSA_STATUS_SUCCESS) {
       *importAddress = info.MemoryAddress;
       *importSize = info.SizeInBytes;
       if (res) {
-        HSAKMT_CALL(hsaKmtDeregisterMemory(*importAddress));
+        driver->DeregisterMemory(*importAddress);
 
         // Manually libDRM import and GPU map system memory
         AMD::GpuAgent* agent = reinterpret_cast<AMD::GpuAgent*>(agents_by_node_[info.NodeId][0]);
@@ -1423,20 +1432,21 @@ hsa_status_t Runtime::IPCAttach(const hsa_amd_ipc_memory_t* handle, size_t len, 
   auto mapMemoryToNodes = [&](unsigned int numNodes, HSAuint32 *nodes) {
     HSAuint64 altAddress;
     if (!numNodes) {
-      if (HSAKMT_CALL(hsaKmtMapMemoryToGPU(importAddress, importSize, &altAddress)) != HSAKMT_STATUS_SUCCESS) {
-        HSAKMT_CALL(hsaKmtDeregisterMemory(importAddress));
+      if (driver->MakeMemoryResident(importAddress, importSize, &altAddress) !=
+          HSA_STATUS_SUCCESS) {
+        driver->DeregisterMemory(importAddress);
         return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
       }
     } else {
       HsaMemMapFlags map_flags;
       map_flags.Value = 0;
       map_flags.ui32.PageSize = HSA_PAGE_SIZE_64KB;
-      if (HSAKMT_CALL(hsaKmtMapMemoryToGPUNodes(importAddress, importSize, &altAddress, map_flags, numNodes,
-                                    nodes)) != HSAKMT_STATUS_SUCCESS) {
+      if (driver->MakeMemoryResident(importAddress, importSize, &altAddress, &map_flags,
+                                     numNodes, nodes) != HSA_STATUS_SUCCESS) {
         map_flags.ui32.PageSize = HSA_PAGE_SIZE_4KB;
-        if (HSAKMT_CALL(hsaKmtMapMemoryToGPUNodes(importAddress, importSize, &altAddress, map_flags, numNodes,
-                                      nodes)) != HSAKMT_STATUS_SUCCESS) {
-          HSAKMT_CALL(hsaKmtDeregisterMemory(importAddress));
+        if (driver->MakeMemoryResident(importAddress, importSize, &altAddress, &map_flags,
+                                       numNodes, nodes) != HSA_STATUS_SUCCESS) {
+          driver->DeregisterMemory(importAddress);
           return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
         }
       }
@@ -1536,9 +1546,9 @@ hsa_status_t Runtime::IPCDetach(void* ptr) {
   }
 
   if (!ldrmImportCleaned) {
-    if (HSAKMT_CALL(hsaKmtUnmapMemoryToGPU(ptr)) != HSAKMT_STATUS_SUCCESS)
+    if (Driver::ShareableMemoryUnmap(ptr) != HSA_STATUS_SUCCESS)
       return HSA_STATUS_ERROR_INVALID_ARGUMENT;
-    if (HSAKMT_CALL(hsaKmtDeregisterMemory(ptr)) != HSAKMT_STATUS_SUCCESS)
+    if (Driver::ShareableMemoryDeregister(ptr) != HSA_STATUS_SUCCESS)
       return HSA_STATUS_ERROR_INVALID_ARGUMENT;
   }
   return HSA_STATUS_SUCCESS;
@@ -3703,7 +3713,7 @@ hsa_status_t Runtime::VMemoryImportShareableHandle(int dmabuf_fd,
   };
 
   HsaGraphicsResourceInfo info;
-  int ret = HSAKMT_CALL(hsaKmtRegisterGraphicsHandleToNodes(dmabuf_fd, &info, 0, NULL));
+  int ret = Driver::RegisterGraphicsHandle(dmabuf_fd, &info, 0, NULL);
   if (ret) return HSA_STATUS_ERROR_INCOMPATIBLE_ARGUMENTS;
 
   ThunkHandle thunk_handle = info.MemoryAddress;

--- a/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -1598,7 +1598,7 @@ void Runtime::AsyncEventsLoop(void* _eventsInfo) {
     constexpr uint32_t wait_ms = 0xFFFFFFFEu;
     HsaEvent** end = std::unique(&hsa_events[0], &hsa_events[0] + unique_evts);
     unique_evts = uint32_t(end - &hsa_events[0]);
-    HSAKMT_CALL(hsaKmtWaitOnMultipleEvents_Ext(&hsa_events[0], unique_evts, false, wait_ms, &event_age[0]));
+    Driver::WaitEventsExt(&hsa_events[0], unique_evts, false, wait_ms, &event_age[0]);
   };
 
   while (!async_events_control_.exit) {

--- a/runtime/hsa-runtime/core/runtime/signal.cpp
+++ b/runtime/hsa-runtime/core/runtime/signal.cpp
@@ -320,7 +320,7 @@ uint32_t Signal::WaitMultiple(uint32_t signal_count, const hsa_signal_t* hsa_sig
     uint64_t ct=timer::duration_cast<std::chrono::milliseconds>(
       time_remaining).count();
     wait_ms = (ct>0xFFFFFFFEu) ? 0xFFFFFFFEu : ct;
-    HSAKMT_CALL(hsaKmtWaitOnMultipleEvents_Ext(evts, unique_evts, wait_on_all, wait_ms, event_age));
+    Driver::WaitEventsExt(evts, unique_evts, wait_on_all, wait_ms, event_age);
   }
 }
 
@@ -425,7 +425,7 @@ uint32_t Signal::WaitAnyExceptions(uint32_t signal_count, const hsa_signal_t* hs
       }
     }
 
-    HSAKMT_CALL(hsaKmtWaitOnMultipleEvents_Ext(evts, unique_evts, false, wait_ms, event_age));
+    Driver::WaitEventsExt(evts, unique_evts, false, wait_ms, event_age);
   } //while
 }
 


### PR DESCRIPTION
The purpose of this PR is for discussion rather than review.

There are many hsakmt calls can not index the agent, they are totally global and some are static method in ROCR.
Like event operations, and many IPC APIs, and the pointer info API.

This PR is separated from:https://github.com/AMD-ROCm-Internal/ROCR-Runtime/pull/233,
cause VIRTIO driver  can work without them. And the design of those drivers need many discussion
and refactor as far as I can see.
