### PR TITLE
rocr: fixing wave_end trap handling

### DIFF
--- a/runtime/hsa-runtime/core/runtime/trap_handler/trap_handler_gfx12.s
+++ b/runtime/hsa-runtime/core/runtime/trap_handler/trap_handler_gfx12.s
@@ -161,13 +161,11 @@ trap_entry:
 
 .not_illegal_instruction:
   s_bitcmp1_b32        ttmp2, SQ_WAVE_EXCP_FLAG_PRIV_WAVE_START_SHIFT
-  s_cbranch_scc0       .not_wave_end
+  s_cbranch_scc0       .not_wave_start
   s_or_b32             ttmp3, ttmp3, EC_QUEUE_WAVE_TRAP_M0
 
 .not_wave_start:
   s_bitcmp1_b32        ttmp2, SQ_WAVE_EXCP_FLAG_PRIV_WAVE_END_SHIFT
-  s_cbranch_scc0       .not_wave_end
-  s_bitcmp1_b32        ttmp13, SQ_WAVE_TRAP_CTRL_WAVE_END_SHIFT
   s_cbranch_scc0       .not_wave_end
   s_or_b32             ttmp3, ttmp3, EC_QUEUE_WAVE_TRAP_M0
 

--- a/runtime/hsa-runtime/core/runtime/trap_handler/trap_handler_gfx12.s
+++ b/runtime/hsa-runtime/core/runtime/trap_handler/trap_handler_gfx12.s
@@ -134,7 +134,7 @@ trap_entry:
   //                                                 -> WAVE_APERTURE_VIOLATION
   // - EXCP_FLAG_PRIV.ILLEGAL_INST                   -> WAVE_ILLEGAL_INSTRUCTION
   // - EXCP_FLAG_PRIV.WAVE_START                     -> WAVE_TRAP
-  // - EXCP_FLAG_PRIV.WAVE_END && TRAP_CTRL.WAVE_END -> WAVE_TRAP
+  // - EXCP_FLAG_PRIV.WAVE_END                       -> WAVE_TRAP
   // - TRAP_CTRL.TRAP_AFTER_INST                     -> WAVE_TRAP
   // - EXCP_FLAG_PRIV.ADDR_WATCH && TRAP_CTL.WATCH   -> WAVE_TRAP
   // - (EXCP_FLAG_USER[ALU] & TRAP_CTRL[ALU]) != 0   -> WAVE_MATH_ERROR


### PR DESCRIPTION
1. Bug: Branching should be to **.not_wave_start**, not to **.not_wave_end.**
2. ttmp13 contains a copy of TRAP_CTRL and, according to gfx1250 SPG:

_Unlike other trap causes, when the trap handler is entered because of trap-on-wavestart or trap-on-
waveend, the associated TRAP_CTRL bit is cleared to zero._

so, we should not be checking SQ_WAVE_TRAP_CTRL_WAVE_END_SHIFT, it will be always zero.