### PR TITLE
rocr: fix nullptr dereference

### DIFF
--- a/runtime/hsa-runtime/core/util/lnx/os_linux.cpp
+++ b/runtime/hsa-runtime/core/util/lnx/os_linux.cpp
@@ -538,6 +538,8 @@ typedef struct EventDescriptor_ {
 EventHandle CreateOsEvent(bool auto_reset, bool init_state) {
   EventDescriptor* eventDescrp;
   eventDescrp = (EventDescriptor*)malloc(sizeof(EventDescriptor));
+  
+  if(!eventDescrp) { return nullptr; }
 
   pthread_mutex_init(&eventDescrp->mutex, NULL);
   pthread_cond_init(&eventDescrp->event, NULL);

--- a/runtime/hsa-runtime/loader/executable.cpp
+++ b/runtime/hsa-runtime/loader/executable.cpp
@@ -1605,6 +1605,8 @@ uint64_t ExecutableImpl::SymbolAddress(hsa_agent_t agent, code::Symbol* sym)
 uint64_t ExecutableImpl::SymbolAddress(hsa_agent_t agent, elf::Symbol* sym)
 {
   elf::Section* sec = sym->section();
+  if(!sec) { return NULL; }
+  
   Segment* seg = SectionSegment(agent, sec);
   uint64_t vaddr = sec->addr() + sym->value();
   return nullptr == seg ? 0 : (uint64_t) (uintptr_t) seg->Address(vaddr);


### PR DESCRIPTION
Return early in the case that malloc fails to avoid dereferencing of a null pointer on eventDescrp.