### PR TITLE
Stop using architecture specific intrinsics in favour of libSIMDe

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Ensure you have the following installed:
 - `libelf-dev`
 - `g++`
 - `libdrm-amdgpu-dev` or `libdrm-dev`
+- `libsimde-dev`
 - `pkg-config`
 - `rocm-core`
 - `rocm-llvm-dev`
@@ -62,7 +63,7 @@ Ensure you have the following installed:
     ```sh
     cmake -DCMAKE_INSTALL_PREFIX=<rocm install dir> ..
     ```
-    e.g: 
+    e.g:
     ```
     cmake -DCMAKE_INSTALL_PREFIX=/opt/rocm ..
     ```

--- a/runtime/hsa-runtime/CMakeLists.txt
+++ b/runtime/hsa-runtime/CMakeLists.txt
@@ -86,6 +86,7 @@ find_package(PkgConfig)
 find_package(LibElf REQUIRED)
 
 pkg_check_modules(drm REQUIRED IMPORTED_TARGET libdrm)
+pkg_check_modules(simde REQUIRED IMPORTED_TARGET simde)
 
 ## Create the rocr target.
 add_library( ${CORE_RUNTIME_TARGET} "" )
@@ -296,7 +297,7 @@ if(${IMAGE_SUPPORT})
 
 endif()
 
-target_link_libraries ( ${CORE_RUNTIME_TARGET} PRIVATE elf::elf dl pthread rt )
+target_link_libraries ( ${CORE_RUNTIME_TARGET} PRIVATE elf::elf dl pthread rt PkgConfig::simde)
 # For static package rocprofiler-register dependency is not required
 # Link to hsakmt target for shared library builds
 # Link to hsakmt-staticdrm target for static library builds

--- a/runtime/hsa-runtime/core/inc/amd_gpu_agent.h
+++ b/runtime/hsa-runtime/core/inc/amd_gpu_agent.h
@@ -63,6 +63,8 @@
 #include "core/util/small_heap.h"
 #include "pcs/pcs_runtime.h"
 
+#include <simde/x86/sse2.h>
+
 namespace rocr {
 namespace AMD {
 class MemoryRegion;
@@ -435,9 +437,9 @@ class GpuAgent : public GpuAgentInt {
   /// @brief Force a WC flush on PCIe devices by doing a write and then read-back
   __forceinline void PcieWcFlush(void *ptr, size_t size) const {
     if (!xgmi_cpu_gpu_) {
-      _mm_sfence();
+      simde_mm_sfence();
       *((uint8_t*)ptr + size - 1) = *((uint8_t*)ptr + size - 1);
-      _mm_mfence();
+      simde_mm_mfence();
       auto readback = *(reinterpret_cast<volatile uint8_t*>(ptr) + size - 1);
       UNUSED(readback);
     }

--- a/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
+++ b/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
@@ -470,7 +470,7 @@ void AqlQueue::StoreRelaxed(hsa_signal_value_t value) {
     HSAKMT_CALL(hsaKmtQueueRingDoorbell(queue_id_));
   } else {
     // Hardware doorbell supports AQL semantics.
-    _mm_sfence();
+    simde_mm_sfence();
     *(signal_.hardware_doorbell_ptr) = uint64_t(value);
     /* signal_ is allocated as uncached so we do not need read-back to flush WC */
   }
@@ -1552,10 +1552,10 @@ void AqlQueue::ExecutePM4(uint32_t* cmd_data, size_t cmd_size_b, hsa_fence_scope
   // Overwrite the AQL invalid header (first dword) last.
   // This prevents the slot from being read until it's fully written.
   memcpy(&queue_slot[1], &slot_data[1], slot_size_b - sizeof(uint32_t));
-  if (IsDeviceMemRingBuf() && needsPcieOrdering()) {
-    // Ensure the packet body is written as header may get reordered when writing over PCIE
-    _mm_sfence();
-  }
+  // Ensure the packet body is written as header may get reordered when
+  // writing over PCIE by doing absolutely nothing since the atomic::Store
+  // helper already takes care of inserting the SFENCE when ORDER_WC is
+  // defined.
   atomic::Store(&queue_slot[0], slot_data[0], std::memory_order_release);
 
   // Submit the packet slot.

--- a/runtime/hsa-runtime/core/runtime/amd_blit_kernel.cpp
+++ b/runtime/hsa-runtime/core/runtime/amd_blit_kernel.cpp
@@ -42,6 +42,8 @@
 
 #include "core/inc/amd_blit_kernel.h"
 
+#include <simde/x86/sse2.h>
+
 #include <algorithm>
 #include <sstream>
 #include <string>
@@ -891,8 +893,9 @@ void BlitKernel::PopulateQueue(uint64_t index, uint64_t code_handle, void* args,
   std::atomic_thread_fence(std::memory_order_release);
   if (queue_->IsDeviceMemRingBuf() && queue_->needsPcieOrdering()) {
     // Ensure the packet body is written as header may get reordered when writing over PCIE
-    _mm_sfence();
+    simde_mm_sfence();
   }
+  // TODO: should convert this to Atomic::Store and drop the explicit SFENCE.
   __atomic_store_n(&(queue_buffer[index & queue_bitmask_].full_header),
                     kDispatchPacketHeader | packet.setup << 16, __ATOMIC_RELEASE);
 

--- a/runtime/hsa-runtime/core/runtime/intercept_queue.cpp
+++ b/runtime/hsa-runtime/core/runtime/intercept_queue.cpp
@@ -260,10 +260,10 @@ uint64_t InterceptQueue::Submit(const AqlPacket* packets, uint64_t count) {
       // Submit barrier which will wake async queue processing.
       ring[barrier & mask].packet.body = {};
       ring[barrier & mask].barrier_and.completion_signal = Signal::Convert(async_doorbell_);
-      if (wrapped->IsDeviceMemRingBuf() && needsPcieOrdering()) {
-        // Ensure the packet body is written as header may get reordered when writing over PCIE
-        _mm_sfence();
-      }
+      // Ensure the packet body is written as header may get reordered when
+      // writing over PCIE by doing absolutely nothing since the atomic::Store
+      // helper already takes care of inserting the SFENCE when ORDER_WC is
+      // defined.
       atomic::Store(&ring[barrier & mask].barrier_and.header, kBarrierHeader,
                     std::memory_order_release);
       // Update the wrapped queue's doorbell so it knows there is a new packet in the queue.
@@ -307,10 +307,10 @@ uint64_t InterceptQueue::Submit(const AqlPacket* packets, uint64_t count) {
         ++packets_index;
       }
       if (write_index != 0) {
-        if (wrapped->IsDeviceMemRingBuf() && needsPcieOrdering()) {
-          // Ensure the packet body is written as header may get reordered when writing over PCIE
-          _mm_sfence();
-        }
+        // Ensure the packet body is written as header may get reordered when
+        // writing over PCIE by doing absolutely nothing since the atomic::Store
+        // helper already takes care of inserting the SFENCE when ORDER_WC is
+        // defined.
         atomic::Store(&ring[write & mask].packet.header, packets[first_written_packet_index].packet.header,
                       std::memory_order_release);
         HSA::hsa_signal_store_screlease(wrapped->amd_queue_.hsa_queue.doorbell_signal,
@@ -376,10 +376,10 @@ void InterceptQueue::StoreRelaxed(hsa_signal_value_t value) {
     Cursor.pkt_index = i;
     auto& handler = interceptors[Cursor.interceptor_index];
     handler.first(&ring[i & mask], 1, i, handler.second, PacketWriter);
-    if (IsDeviceMemRingBuf() && needsPcieOrdering()) {
-      // Ensure the packet body is written as header may get reordered when writing over PCIE
-      _mm_sfence();
-    }
+    // Ensure the packet body is written as header may get reordered when
+    // writing over PCIE by doing absolutely nothing since the atomic::Store
+    // helper already takes care of inserting the SFENCE when ORDER_WC is
+    // defined.
     // Invalidate consumed packet.
     atomic::Store(&ring[i & mask].packet.header, kInvalidHeader, std::memory_order_release);
 

--- a/runtime/hsa-runtime/core/util/atomic_helpers.h
+++ b/runtime/hsa-runtime/core/util/atomic_helpers.h
@@ -2,24 +2,24 @@
 //
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
-// 
+//
 // Copyright (c) 2014-2020, Advanced Micro Devices, Inc. All rights reserved.
-// 
+//
 // Developed by:
-// 
+//
 //                 AMD Research and AMD HSA Software Development
-// 
+//
 //                 Advanced Micro Devices, Inc.
-// 
+//
 //                 www.amd.com
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to
 // deal with the Software without restriction, including without limitation
 // the rights to use, copy, modify, merge, publish, distribute, sublicense,
 // and/or sell copies of the Software, and to permit persons to whom the
 // Software is furnished to do so, subject to the following conditions:
-// 
+//
 //  - Redistributions of source code must retain the above copyright notice,
 //    this list of conditions and the following disclaimers.
 //  - Redistributions in binary form must reproduce the above copyright
@@ -29,7 +29,7 @@
 //    nor the names of its contributors may be used to endorse or promote
 //    products derived from this Software without specific prior written
 //    permission.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
@@ -55,11 +55,12 @@
 #define ALWAYS_CONSERVATIVE 0
 
 #if !ALWAYS_CONSERVATIVE
-#if defined(__x86_64__) || defined(_M_X64)
-#define X64_ORDER_WC 1
+#if defined(__x86_64__) || defined(_M_X64) || defined(__aarch64__) ||          \
+    defined(_M_ARM64)
+#define ORDER_WC 1
 #endif
-#if X64_ORDER_WC
-#include <xmmintrin.h>
+#if ORDER_WC
+#include <simde/x86/sse2.h>
 #endif
 #endif
 
@@ -70,7 +71,7 @@ static constexpr int c11ToBuiltInFlags(std::memory_order order)
 {
 #if ALWAYS_CONSERVATIVE
   return __ATOMIC_RELAXED;
-#elif X64_ORDER_WC
+#elif ORDER_WC
   return __ATOMIC_RELAXED;
 #else
   return (order == std::memory_order_relaxed) ? __ATOMIC_RELAXED :
@@ -92,12 +93,12 @@ static __forceinline void PreFence(std::memory_order order) {
       __atomic_thread_fence(__ATOMIC_SEQ_CST);
     default:;
   }
-#elif X64_ORDER_WC
+#elif ORDER_WC
   switch (order) {
     case std::memory_order_release:
     case std::memory_order_seq_cst:
     case std::memory_order_acq_rel:
-      _mm_sfence();
+      simde_mm_sfence();
     default:;
   }
 #endif
@@ -112,13 +113,13 @@ static __forceinline void PostFence(std::memory_order order) {
       __atomic_thread_fence(__ATOMIC_SEQ_CST);
     default:;
   }
-#elif X64_ORDER_WC
+#elif ORDER_WC
   switch (order) {
     case std::memory_order_seq_cst:
-      return _mm_mfence();
+      return simde_mm_mfence();
     case std::memory_order_acq_rel:
     case std::memory_order_acquire:
-      return _mm_lfence();
+      return simde_mm_lfence();
     default:;
   }
 #endif
@@ -127,15 +128,15 @@ static __forceinline void PostFence(std::memory_order order) {
 static __forceinline void Fence(std::memory_order order=std::memory_order_seq_cst) {
 #if ALWAYS_CONSERVATIVE
   __atomic_thread_fence(__ATOMIC_SEQ_CST);
-#elif X64_ORDER_WC
+#elif ORDER_WC
   switch (order) {
     case std::memory_order_seq_cst:
     case std::memory_order_acq_rel:
-      return _mm_mfence();
+      return simde_mm_mfence();
     case std::memory_order_acquire:
-      return _mm_lfence();
+      return simde_mm_lfence();
     case std::memory_order_release:
-      return _mm_sfence();
+      return simde_mm_sfence();
     default:;
   }
 #else
@@ -507,8 +508,8 @@ static __forceinline T
 }   //  namespace atomic
 }   //  namespace rocr
 
-#ifdef X64_ORDER_WC
-#undef X64_ORDER_WC
+#ifdef ORDER_WC
+#undef ORDER_WC
 #endif
 
 #ifdef ALWAYS_CONSERVATIVE

--- a/runtime/hsa-runtime/core/util/locks.h
+++ b/runtime/hsa-runtime/core/util/locks.h
@@ -2,24 +2,24 @@
 //
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
-// 
+//
 // Copyright (c) 2014-2020, Advanced Micro Devices, Inc. All rights reserved.
-// 
+//
 // Developed by:
-// 
+//
 //                 AMD Research and AMD HSA Software Development
-// 
+//
 //                 Advanced Micro Devices, Inc.
-// 
+//
 //                 www.amd.com
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to
 // deal with the Software without restriction, including without limitation
 // the rights to use, copy, modify, merge, publish, distribute, sublicense,
 // and/or sell copies of the Software, and to permit persons to whom the
 // Software is furnished to do so, subject to the following conditions:
-// 
+//
 //  - Redistributions of source code must retain the above copyright notice,
 //    this list of conditions and the following disclaimers.
 //  - Redistributions in binary form must reproduce the above copyright
@@ -29,7 +29,7 @@
 //    nor the names of its contributors may be used to endorse or promote
 //    products derived from this Software without specific prior written
 //    permission.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
@@ -48,16 +48,18 @@
 #include "utils.h"
 #include "os.h"
 
+#include <simde/x86/sse2.h>
+
 namespace rocr {
 
 class HybridMutex {
  public:
-  HybridMutex():lock_(0) { 
-    sem_ = os::CreateSemaphore(); 
+  HybridMutex():lock_(0) {
+    sem_ = os::CreateSemaphore();
   }
 
-  ~HybridMutex() { 
-    os::DestroySemaphore(sem_); 
+  ~HybridMutex() {
+    os::DestroySemaphore(sem_);
   }
 
   bool Try() {
@@ -72,7 +74,7 @@ class HybridMutex {
     while (!lock_.compare_exchange_strong(old, 1)) {
       cnt--;
       if (cnt > maxSpinIterPause) {
-        _mm_pause();
+        simde_mm_pause();
       } else if (cnt-- > maxSpinIterYield) {
         os::YieldThread();
       } else {

--- a/runtime/hsa-runtime/core/util/utils.h
+++ b/runtime/hsa-runtime/core/util/utils.h
@@ -50,6 +50,9 @@
 #include "stdlib.h"
 #include "stdarg.h"
 #include "unistd.h"
+
+#include <simde/x86/sse2.h>
+
 #include <assert.h>
 #include <iostream>
 #include <string>
@@ -65,9 +68,6 @@ typedef unsigned int uint;
 typedef uint64_t uint64;
 
 #if defined(__GNUC__)
-#if defined(__i386__) || defined(__x86_64__)
-#include <x86intrin.h>
-#endif
 
 #define __forceinline __inline__ __attribute__((always_inline))
 #define __declspec(x) __attribute__((x))
@@ -372,7 +372,7 @@ inline void FlushCpuCache(const void* base, size_t offset, size_t len) {
   cur += offset;
   uintptr_t lastline = (uintptr_t)(cur + len - 1) | (cacheline_size - 1);
   do {
-    _mm_clflush((const void*)cur);
+    simde_mm_clflush((const void*)cur);
     cur += cacheline_size;
   } while (cur <= (const char*)lastline);
 }

--- a/runtime/hsa-runtime/image/image_manager.cpp
+++ b/runtime/hsa-runtime/image/image_manager.cpp
@@ -53,8 +53,9 @@
 #include <cmath>
 
 #if (defined(WIN32) || defined(_WIN32))
+#include <simde/x86/sse.h>
 #define NOMINMAX
-__inline long int lrintf(float f) { return _mm_cvtss_si32(_mm_load_ss(&f)); }
+__inline long int lrintf(float f) { return simde_mm_cvtss_si32(simde_mm_load_ss(&f)); }
 #endif
 
 namespace rocr {


### PR DESCRIPTION


Mirrored from source PR: https://github.com/ROCm/ROCR-Runtime/pull/314
Commit: fa154f5dbdadee331c03238b015fee8b122849df