### PR TITLE
hsakmt: Removed static version of libhsakmt from public

### DIFF
--- a/libhsakmt/CMakeLists.txt
+++ b/libhsakmt/CMakeLists.txt
@@ -201,24 +201,30 @@ if( CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT )
 endif()
 set ( CMAKE_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX} CACHE STRING "Default installation directory." FORCE )
 
-# Installs binaries and exports the library usage data to ${HSAKMT_TARGET}Targets
-install ( TARGETS ${HSAKMT_TARGET} EXPORT ${HSAKMT_TARGET}Targets
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT asan
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT asan )
-install ( TARGETS ${HSAKMT_TARGET}
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT binary
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT binary )
-
 # Install public headers
 install ( DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/${HSAKMT_TARGET} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
   COMPONENT dev PATTERN "linux" EXCLUDE PATTERN "*virtio*" EXCLUDE)
 
-# Record our usage data for clients find_package calls.
-install ( EXPORT ${HSAKMT_TARGET}Targets
-  FILE ${HSAKMT_TARGET}Targets.cmake
-  NAMESPACE ${HSAKMT_TARGET}::
-  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${HSAKMT_TARGET}
-  COMPONENT dev)
+# Option to build header path migration helpers.
+option(INCLUDE_PATH_COMPATIBILITY "Generate backward compatible headers and include paths.  Use of these headers will warn when included." OFF)
+
+if(INCLUDE_PATH_COMPATIBILITY)
+  # To enable/disable #error in wrapper header files
+  if(NOT DEFINED ROCM_HEADER_WRAPPER_WERROR)
+      if(DEFINED ENV{ROCM_HEADER_WRAPPER_WERROR})
+          set(ROCM_HEADER_WRAPPER_WERROR "$ENV{ROCM_HEADER_WRAPPER_WERROR}"
+                  CACHE STRING "Header wrapper warnings as errors.")
+      else()
+          set(ROCM_HEADER_WRAPPER_WERROR "OFF" CACHE STRING "Header wrapper warnings as errors.")
+      endif()
+  endif()
+  if(ROCM_HEADER_WRAPPER_WERROR)
+      set(deprecated_error 1)
+  else()
+      set(deprecated_error 0)
+  endif()
+  include(hsakmt-backward-compat.cmake)
+endif()
 
 # Adds the target alias hsakmt::hsakmt to the local cmake cache.
 # This isn't necessary today.  It's harmless preparation for some
@@ -227,26 +233,6 @@ install ( EXPORT ${HSAKMT_TARGET}Targets
 # and target_link_library() without regard to whether a target is external or
 # a subdirectory of the current build.
 add_library( ${HSAKMT_TARGET}::${HSAKMT_TARGET} ALIAS ${HSAKMT_TARGET} )
-
-# Create cmake configuration files
-include(CMakePackageConfigHelpers)
-
-configure_package_config_file(${HSAKMT_TARGET}-config.cmake.in
-                            ${HSAKMT_TARGET}-config.cmake
-                            INSTALL_DESTINATION
-                            ${CMAKE_INSTALL_LIBDIR}/cmake/${HSAKMT_TARGET} )
-
-write_basic_package_version_file(${HSAKMT_TARGET}-config-version.cmake
-                 VERSION ${BUILD_VERSION_STRING}
-                 COMPATIBILITY
-                 AnyNewerVersion)
-
-install(FILES
-        ${CMAKE_CURRENT_BINARY_DIR}/${HSAKMT_TARGET}-config.cmake
-        ${CMAKE_CURRENT_BINARY_DIR}/${HSAKMT_TARGET}-config-version.cmake
-        DESTINATION
-        ${CMAKE_INSTALL_LIBDIR}/cmake/${HSAKMT_TARGET}
-        COMPONENT dev)
 
 # Optionally record the package's find module in the user's package cache.
 if ( NOT DEFINED EXPORT_TO_USER_PACKAGE_REGISTRY )
@@ -269,7 +255,26 @@ configure_file ( libhsakmt.pc.in libhsakmt.pc @ONLY )
 
 install ( FILES ${CMAKE_CURRENT_BINARY_DIR}/libhsakmt.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig COMPONENT dev)
 
-if ( NOT BUILD_SHARED_LIBS)
+if(NOT BUILD_SHARED_LIBS)
+  include(CMakePackageConfigHelpers)
+
+  configure_package_config_file(${HSAKMT_TARGET}-config.cmake.in
+                            ${HSAKMT_TARGET}-config.cmake
+                            INSTALL_DESTINATION
+                            ${CMAKE_INSTALL_LIBDIR}/cmake/${HSAKMT_TARGET} )
+
+  write_basic_package_version_file(${HSAKMT_TARGET}-config-version.cmake
+                 VERSION ${BUILD_VERSION_STRING}
+                 COMPATIBILITY
+                 AnyNewerVersion)
+
+  install(FILES
+        ${CMAKE_CURRENT_BINARY_DIR}/${HSAKMT_TARGET}-config.cmake
+        ${CMAKE_CURRENT_BINARY_DIR}/${HSAKMT_TARGET}-config-version.cmake
+        DESTINATION
+        ${CMAKE_INSTALL_LIBDIR}/cmake/${HSAKMT_TARGET}
+        COMPONENT dev)
+
   ## Create separate target file for static builds
   ## In static builds, libdrm and libdrm_amdgpu need to be linked statically
   add_library (${HSAKMT_STATIC_DRM_TARGET}  STATIC "")

--- a/libhsakmt/hsakmt-config.cmake.in
+++ b/libhsakmt/hsakmt-config.cmake.in
@@ -10,10 +10,7 @@ include( CMakeFindDependencyMacro )
 # find_dependencies as shown below.
 #find_dependency(Bar, 2.0)
 
-# If the option is ON link other dependent libraries dynamically
-# If the option is OFF, then link libdrm and libdrm_amdgpu statically
-if(@BUILD_SHARED_LIBS@)
-  include( "${CMAKE_CURRENT_LIST_DIR}/@HSAKMT_TARGET@Targets.cmake" )
-else()
-  include( "${CMAKE_CURRENT_LIST_DIR}/@HSAKMT_STATIC_DRM_TARGET@Targets.cmake" )
-endif()
+# If the "shared_libs" option is ON link other dependent libraries dynamically
+# If the "shared_libs" option is OFF, then link libdrm and libdrm_amdgpu statically
+include( "${CMAKE_CURRENT_LIST_DIR}/@HSAKMT_STATIC_DRM_TARGET@Targets.cmake" )
+

--- a/libhsakmt/libhsakmt.pc.in
+++ b/libhsakmt/libhsakmt.pc.in
@@ -1,11 +1,7 @@
 prefix=${pcfiledir}/../..
-exec_prefix=${prefix}
-libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
 includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
 
 Name: libhsakmt
 Description: HSA Kernel Mode Thunk library for AMD KFD support
 Version: @LIB_VERSION_STRING@
-
-Libs: -L${libdir} -lhsakmt
 Cflags: -I${includedir}

--- a/libhsakmt/tests/kfdtest/CMakeLists.txt
+++ b/libhsakmt/tests/kfdtest/CMakeLists.txt
@@ -103,17 +103,17 @@ if( DEFINED ENV{LIBHSAKMT_PATH} )
     set ( LIBHSAKMT_PATH $ENV{LIBHSAKMT_PATH} )
     message ( "LIBHSAKMT_PATH environment variable is set" )
 else()
-    if ( ${ROCM_INSTALL_PATH} )
-       set ( ENV{PKG_CONFIG_PATH} ${ROCM_INSTALL_PATH}/share/pkgconfig )
-    else()
-       set ( ENV{PKG_CONFIG_PATH} /opt/rocm/share/pkgconfig )
-    endif()
+  find_path(LIBHSAKMT_PATH NAMES libhsakmt.a
+    PATHS ${CMAKE_CURRENT_BINARY_DIR}/../rocr/libhsakmt/archive
+    PATHS ${CMAKE_CURRENT_BINARY_DIR}/../rocr/libhsakmt )
+endif()
 
-    pkg_check_modules(HSAKMT libhsakmt)
-
-    if( NOT HSAKMT_FOUND )
-       set ( LIBHSAKMT_PATH $ENV{OUT_DIR} )
-    endif()
+if ( BUILD_SHARED_LIBS)
+find_path(LIBHSAKMT_PATH NAMES libhsakmt.a
+  PATHS ${CMAKE_CURRENT_BINARY_DIR}/../rocr/libhsakmt/archive)
+else()
+find_path(LIBHSAKMT_PATH NAMES libhsakmt-staticdrm.a
+  PATHS ${CMAKE_CURRENT_BINARY_DIR}/../rocr/libhsakmt/archive)
 endif()
 
 if( DEFINED LIBHSAKMT_PATH )
@@ -247,15 +247,19 @@ link_directories(${HSAKMT_LIBRARY_DIRS})
 
 add_executable(kfdtest ${SRC_FILES})
 
-target_link_libraries(kfdtest ${HSAKMT_LIBRARIES} ${DRM_LDFLAGS} ${DRM_AMDGPU_LDFLAGS} ${llvm_libs} pthread m stdc++ rt numa)
+if(BUILD_SHARED_LIBS)
+  target_link_libraries(kfdtest ${HSAKMT_LIBRARIES} ${DRM_LDFLAGS} ${DRM_AMDGPU_LDFLAGS} ${llvm_libs} pthread m stdc++ rt numa)
+else()
+  target_link_libraries(kfdtest  ${llvm_libs} pthread m stdc++ rt numa hsakmt-staticdrm::hsakmt-staticdrm)
+endif()
 
 configure_file ( scripts/kfdtest.exclude kfdtest.exclude COPYONLY )
 configure_file ( scripts/run_kfdtest.sh run_kfdtest.sh COPYONLY )
 
 install( PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/kfdtest ${CMAKE_CURRENT_BINARY_DIR}/run_kfdtest.sh
-	DESTINATION bin )
+        DESTINATION bin )
 install( FILES ${CMAKE_CURRENT_BINARY_DIR}/kfdtest.exclude
-	DESTINATION share/kfdtest )
+        DESTINATION share/kfdtest )
 # Remove dependency on rocm-core if -DROCM_DEP_ROCMCORE=ON not given to cmake
 if(NOT ROCM_DEP_ROCMCORE)
     string(REGEX REPLACE ",? ?rocm-core" "" CPACK_RPM_PACKAGE_REQUIRES ${CPACK_RPM_PACKAGE_REQUIRES})


### PR DESCRIPTION
    Removed the static version of the HSAKMT library (libhsakmt.a)
    from the shared release packages because, there were some missing
    exported symbols.  This library was only meant to be used
    internally and therefore should not be included in any public
    release.