### PR TITLE
kfdtest: add cwsr save area check test for GFX12

### DIFF
--- a/libhsakmt/tests/kfdtest/src/Dispatch.cpp
+++ b/libhsakmt/tests/kfdtest/src/Dispatch.cpp
@@ -35,7 +35,8 @@
 Dispatch::Dispatch(const HsaMemoryBuffer& isaBuf, const bool eventAutoReset)
     :m_IsaBuf(isaBuf), m_IndirectBuf(PACKETTYPE_PM4, PAGE_SIZE / sizeof(unsigned int), isaBuf.Node()),
     m_DimX(1), m_DimY(1), m_DimZ(1), m_pArg1(NULL), m_pArg2(NULL), m_pEop(NULL), m_ScratchEn(false),
-    m_ComputeTmpringSize(0), m_scratch_base(0ll), m_SpiPriority(0) {
+    m_ComputeTmpringSize(0), m_scratch_base(0ll), m_SpiPriority(0), m_WaveMemInfo({0}),
+    m_PacketAddrLo(0) {
     HsaEventDescriptor eventDesc;
     eventDesc.EventType = HSA_EVENTTYPE_SIGNAL;
     eventDesc.NodeId = isaBuf.Node();
@@ -46,6 +47,22 @@ Dispatch::Dispatch(const HsaMemoryBuffer& isaBuf, const bool eventAutoReset)
 
     m_FamilyId  = g_baseTest->GetFamilyIdFromNodeId(isaBuf.Node());
     m_NeedCwsrWA = g_baseTest->NeedCwsrWA(isaBuf.Node());
+
+    m_WaveMemInfo.isWave32 = true;
+    m_WaveMemInfo.numVgpr = 32;
+    m_WaveMemInfo.numBytesLds = 0;
+    m_WaveMemInfo.numTtemps = 16;
+
+    // For VGPR & LDS test setting.  Support GFX12 only for now.
+    if (m_FamilyId == FAMILY_GFX12) {
+        m_WaveMemInfo.maxNumVgpr = 256;
+        m_WaveMemInfo.vgprBlockSize = 8;
+        m_WaveMemInfo.maxNumSgpr = 128;
+        m_WaveMemInfo.sgprBlockSize = 128;
+        m_WaveMemInfo.numUserSgpr = 106;
+        m_WaveMemInfo.maxBytesLds = 16384;
+        m_WaveMemInfo.ldsBlockSize = 512;
+    }
 }
 
 Dispatch::~Dispatch() {
@@ -76,6 +93,54 @@ void Dispatch::SetSpiPriority(unsigned int priority) {
 
 void Dispatch::SetPriv(bool priv) {
     m_NeedCwsrWA = priv;
+}
+
+HSAKMT_STATUS Dispatch::SetNumVgprs(unsigned int numVgprs, unsigned int *maxSize, unsigned int *blockSize) {
+    *maxSize = 0;
+    *blockSize = 0;
+    unsigned int vgprMaxSize = m_WaveMemInfo.maxNumVgpr;
+    unsigned int vgprBlockSize = m_WaveMemInfo.vgprBlockSize;
+
+    if (!(vgprMaxSize && vgprBlockSize))
+        return HSAKMT_STATUS_UNAVAILABLE;
+
+    *maxSize = vgprMaxSize;
+    *blockSize = vgprBlockSize;
+
+    if (numVgprs > *maxSize || !!(numVgprs % *blockSize))
+        return HSAKMT_STATUS_MEMORY_ALIGNMENT;
+
+    m_WaveMemInfo.numVgpr = numVgprs;
+
+    return HSAKMT_STATUS_SUCCESS;
+}
+
+HSAKMT_STATUS Dispatch::SetLdsSize(size_t ldsSizeInBytes, size_t *maxSize, size_t *blockSize) {
+    *maxSize = 0;
+    *blockSize = 0;
+    size_t ldsMaxSize = m_WaveMemInfo.maxBytesLds;
+    size_t ldsBlockSize = m_WaveMemInfo.ldsBlockSize;
+
+    if (!(ldsMaxSize && ldsBlockSize))
+        return HSAKMT_STATUS_UNAVAILABLE;
+
+    *maxSize = ldsMaxSize;
+    *blockSize = ldsBlockSize;
+
+    if (ldsSizeInBytes > *maxSize || !!(ldsSizeInBytes % *blockSize))
+        return HSAKMT_STATUS_MEMORY_ALIGNMENT;
+
+    m_WaveMemInfo.numBytesLds = ldsSizeInBytes;
+    return HSAKMT_STATUS_SUCCESS;
+}
+
+void Dispatch::SetWave32(bool isWave32) {
+    m_WaveMemInfo.isWave32 = isWave32;
+    m_WaveMemInfo.vgprBlockSize = isWave32 ? 8 : 4;
+}
+
+void Dispatch::SetPacketAddrLo(uint32_t addrLo) {
+    m_PacketAddrLo = addrLo;
 }
 
 void Dispatch::Submit(BaseQueue& queue) {
@@ -133,12 +198,18 @@ void Dispatch::BuildIb() {
      */
     const bool priv = m_NeedCwsrWA;
 
+    // Wave32/Wave64 VGPR range is 0-63 where:
+    // Wave32 => 8,16,24,...,256
+    // Wave64 => 4,8,12,...,256
+    const unsigned int numVgpr = (m_WaveMemInfo.numVgpr >>
+                                 (m_WaveMemInfo.isWave32 ? 3 : 2)) - 1;
+
     unsigned int pgmRsrc1 =
         (0xc0 << COMPUTE_PGM_RSRC1__FLOAT_MODE__SHIFT) |
         ((m_SpiPriority & 3) << COMPUTE_PGM_RSRC1__PRIORITY__SHIFT) |
         (priv << COMPUTE_PGM_RSRC1__PRIV__SHIFT) |
         ((m_FamilyId < FAMILY_GFX12) ? (0x2 << COMPUTE_PGM_RSRC1__SGPRS__SHIFT) : 0) |
-        (0x4 << COMPUTE_PGM_RSRC1__VGPRS__SHIFT);  // 4 * 8 = 32 VGPRs
+        (numVgpr << COMPUTE_PGM_RSRC1__VGPRS__SHIFT);
 
     unsigned int pgmRsrc2 = 0;
     pgmRsrc2 |= (m_ScratchEn << COMPUTE_PGM_RSRC2__SCRATCH_EN__SHIFT)
@@ -151,6 +222,9 @@ void Dispatch::BuildIb() {
             & COMPUTE_PGM_RSRC2__TRAP_PRESENT_MASK;
     }
 
+    const size_t ldsSize = m_WaveMemInfo.ldsBlockSize ?
+                           m_WaveMemInfo.numBytesLds/m_WaveMemInfo.ldsBlockSize : 0;
+
     pgmRsrc2 |= (1 << COMPUTE_PGM_RSRC2__TGID_X_EN__SHIFT)
             & COMPUTE_PGM_RSRC2__TGID_X_EN_MASK;
     pgmRsrc2 |= (1 << COMPUTE_PGM_RSRC2__TIDIG_COMP_CNT__SHIFT)
@@ -159,6 +233,8 @@ void Dispatch::BuildIb() {
             & COMPUTE_PGM_RSRC2__EXCP_EN_MASK;
     pgmRsrc2 |= (1 << COMPUTE_PGM_RSRC2__EXCP_EN_MSB__SHIFT)
             & COMPUTE_PGM_RSRC2__EXCP_EN_MSB_MASK;
+    pgmRsrc2 |= (ldsSize << COMPUTE_PGM_RSRC2__LDS_SIZE__SHIFT)
+	    & COMPUTE_PGM_RSRC2__LDS_SIZE_MASK;
 
     const unsigned int COMPUTE_PGM_RSRC[] = {
         pgmRsrc1,
@@ -223,11 +299,15 @@ void Dispatch::BuildIb() {
     };
 
     const unsigned int DISPATCH_INIT_VALUE = 0x00000021 | (hsakmt_is_dgpu() ? 0 : 0x1000) |
-                ((m_FamilyId >= FAMILY_NV) ? 0x8000 : 0);
+                ((m_FamilyId >= FAMILY_NV && m_WaveMemInfo.isWave32) ? 0x8000 : 0);
     // {COMPUTE_SHADER_EN=1, PARTIAL_TG_EN=0, FORCE_START_AT_000=0, ORDERED_APPEND_ENBL=0,
     // ORDERED_APPEND_MODE=0, USE_THREAD_DIMENSIONS=1, ORDER_MODE=0, DISPATCH_CACHE_CNTL=0,
     // SCALAR_L1_INV_VOL=0, VECTOR_L1_INV_VOL=0, DATA_ATC=?, RESTORE=0}
     // Set CS_W32_EN for wave32 workloads for gfx10 since all the shaders used in KFDTest is 32 bit .
+
+    const unsigned int COMPUTE_DISPATCH_PKT_ADDR_LO[] = {
+        m_PacketAddrLo,
+    };
 
     m_IndirectBuf.AddPacket(PM4AcquireMemoryPacket(m_FamilyId));
 
@@ -255,6 +335,10 @@ void Dispatch::BuildIb() {
 
     m_IndirectBuf.AddPacket(PM4SetShaderRegPacket(mmCOMPUTE_USER_DATA_0, COMPUTE_USER_DATA_VALUES,
                                                   ARRAY_SIZE(COMPUTE_USER_DATA_VALUES)));
+
+    //COMPUTE_TBA_LO is deprecated and is now replaced by mmCOMPUTE_DISPATCH_PKT_ADDR_LO
+    m_IndirectBuf.AddPacket(PM4SetShaderRegPacket(mmCOMPUTE_TBA_LO, COMPUTE_DISPATCH_PKT_ADDR_LO,
+                                                  ARRAY_SIZE(COMPUTE_DISPATCH_PKT_ADDR_LO)));
 
     m_IndirectBuf.AddPacket(PM4DispatchDirectPacket(m_DimX, m_DimY, m_DimZ, DISPATCH_INIT_VALUE));
 

--- a/libhsakmt/tests/kfdtest/src/Dispatch.hpp
+++ b/libhsakmt/tests/kfdtest/src/Dispatch.hpp
@@ -48,7 +48,32 @@ class Dispatch {
     
     void SetPriv(bool priv);
 
+    HSAKMT_STATUS SetNumVgprs(unsigned int numVgprs, unsigned int *maxSize, unsigned int *blockSize);
+
+    HSAKMT_STATUS SetLdsSize(size_t ldsSizeInBytes, size_t *maxSize, size_t *blockSize);
+
+    void SetWave32(bool isWave32);
+
     HsaEvent *GetHsaEvent() { return m_pEop; }
+
+    struct WaveMemInfo {
+        bool isWave32;
+        unsigned int numVgpr;
+        unsigned int maxNumVgpr;
+        unsigned int vgprBlockSize;
+        unsigned int numSgpr;
+        unsigned int maxNumSgpr;
+        unsigned int sgprBlockSize;
+        unsigned int numUserSgpr;
+        unsigned int numTtemps;
+        size_t numBytesLds;
+        size_t maxBytesLds;
+        size_t ldsBlockSize;
+    };
+
+    struct WaveMemInfo GetWaveMemInfo() { return m_WaveMemInfo; }
+
+    void SetPacketAddrLo(uint32_t addrLo);
 
  private:
     void BuildIb();
@@ -74,6 +99,8 @@ class Dispatch {
     unsigned int m_SpiPriority;
     unsigned int  m_FamilyId;
     bool  m_NeedCwsrWA;
+    struct WaveMemInfo m_WaveMemInfo;
+    uint32_t m_PacketAddrLo;
 };
 
 #endif  // __KFD_DISPATCH__H__

--- a/libhsakmt/tests/kfdtest/src/KFDCWSRTest.cpp
+++ b/libhsakmt/tests/kfdtest/src/KFDCWSRTest.cpp
@@ -252,3 +252,272 @@ TEST_F(KFDCWSRTest, InterruptRestore) {
 
     TEST_END
 }
+
+#define CWSR_WAVE_MEM_TYPE_VGPR		0
+#define CWSR_WAVE_MEM_TYPE_SGPR		1
+#define CWSR_WAVE_MEM_TYPE_LDS		2
+#define CWSR_WAVE_MEM_TYPE_EXEC		3
+#define CWSR_WAVE_MEM_TYPE_PKT_LO	4
+// Helper for SaveAreCheck test to match seeded wave memory words
+// wordAddr auto increments on word search
+static int CheckWaveMemBlockWords(int memType, int waveSize, uint32_t **wordAddr, int numWords,
+                                  uint32_t mask) {
+    int wordCount = 0, searchStart = 0;
+    bool wordFound = false;
+
+    if (memType == CWSR_WAVE_MEM_TYPE_PKT_LO)
+        mask &= 0x1ffffff; // saved as 25 bits in ttmp8
+
+    for (int i = 0; i < numWords; i++) {
+        uint32_t word =  (*wordAddr)[i], lane = word & 0xffff;
+        bool match = memType == CWSR_WAVE_MEM_TYPE_VGPR ?
+                     (word & mask) == mask && ((i - searchStart) % waveSize == lane) :
+                     word == mask;
+	
+        if (match) {
+            wordFound = true;
+            wordCount++;
+   	} else {
+            if (wordFound)
+                break;
+            searchStart++;
+            continue;
+	}
+
+    }
+
+    *wordAddr += (searchStart + wordCount);
+
+    return wordCount;
+}	
+
+enum SaveAreaTestCase {
+    SAVE_AREA_TEST_WAVE_MEM = 0,
+    SAVE_AREA_TEST_WAVE_BLOCKS,
+    SAVE_AREA_TEST_RAND_MEM_SIZE,
+    SAVE_AREA_TEST_RAND_WAVE_BLOCKS,
+    SAVE_AREA_TEST_WAVE_MEM_64,
+    SAVE_AREA_TEST_WAVE_BLOCKS_64,
+    SAVE_AREA_TEST_RAND_MEM_SIZE_64,
+    SAVE_AREA_TEST_RAND_WAVE_BLOCKS_64,
+    SAVE_AREA_TEST_MAX
+};
+
+/**
+ * KFDCWSRTest.SaveAreaCheck
+ *
+ * Shader/Dispatch seeds wave memory with the following:
+ * VGPR word = 0xffff00<ll> where ll = lane ID
+ * SGPR word = 0x87654321
+ * LDS word = 0x12345678
+ * EXEC LO = 0x1010101, EXEC_HI = 0x2020202
+ * Dispatch Packet ADDR Lo = 0x1abcabc
+ *
+ * After dispatch, test checks 2 buffers for initialization status.
+ * initBuf[waveId] => Shader writes non-zero to each waveId to signal
+ *                    wave memory initialization is ready
+ * execBuf[laneId] => All waves vector write non-zero to laneId to
+ *                    hint EXEC mask after initBuf signaled
+ *
+ * Test launch 10 CWSRs then crawls through wave memory to check
+ * seeded values.
+ *
+ * After check, test signals shader termination.
+ * Shader rechecks reads on initBuf & execBuf as buffer address are
+ * saved in v0-v3 & s0-s3.
+ *
+ * Test is run in both Wave32/64 as well as fixed and random
+ * VGPR & LDS allocations.
+ * SGPR allocation is fixed in HW.
+ */
+static void SaveAreaCheck(KFDTEST_PARAMETERS* pTestParamters) {
+    int gpuNode = pTestParamters->gpuNode;
+    KFDCWSRTest* pKFDCWSRTest = (KFDCWSRTest*)pTestParamters->pTestObject;
+
+    const HSAuint32 m_FamilyId = pKFDCWSRTest->GetFamilyIdFromNodeId(gpuNode);
+
+    Assembler* m_pAsm;
+    m_pAsm = pKFDCWSRTest->GetAssemblerFromNodeId(gpuNode);
+    ASSERT_NOTNULL_GPU(m_pAsm, gpuNode);
+
+    if ((m_FamilyId >= FAMILY_GFX12) && (checkCWSREnabled())) {
+        HsaMemoryBuffer isaBuffer(PAGE_SIZE, gpuNode, true/*zero*/, false/*local*/, true/*exec*/);
+
+        ASSERT_SUCCESS_GPU(m_pAsm->RunAssembleBuf(InitWaveMemoryIsa, isaBuffer.As<char*>()), gpuNode);
+
+        HsaMemoryBuffer execBuf(PAGE_SIZE, gpuNode, true, false, false);
+        HsaMemoryBuffer initBuf(PAGE_SIZE * 2, gpuNode, true, false, false);
+        unsigned int* execVal = execBuf.As<unsigned int*>();
+        unsigned int* initVal = initBuf.As<unsigned int*>();
+        uint32_t ldsMask = 0x12345678, sgprMask = 0x87654321, vgprMask = 0xffff0000;
+        uint32_t pktLoMask = 0x1abcabc;
+        uint32_t vgprMax, vgprBlockSize;
+        size_t ldsMax, ldsBlockSize;
+        srand((unsigned) time(NULL)); // seed for random allocation tests
+
+        for (int tcase = SAVE_AREA_TEST_WAVE_MEM; tcase < SAVE_AREA_TEST_MAX; tcase++) {
+
+            // reinit memory
+            execBuf.Fill(0);
+            initBuf.Fill(0);
+
+            PM4Queue queue;
+            ASSERT_SUCCESS_GPU(queue.Create(gpuNode), gpuNode);
+            Dispatch *dispatch = new Dispatch(isaBuffer);
+            if (tcase > SAVE_AREA_TEST_RAND_WAVE_BLOCKS)
+                dispatch->SetWave32(false); // Wave64
+            dispatch->SetPacketAddrLo(pktLoMask);
+            Dispatch::WaveMemInfo waveInfo = dispatch->GetWaveMemInfo();
+            int numWaves = 1;
+            unsigned int numVgpr = waveInfo.maxNumVgpr;
+            size_t ldsSize = waveInfo.maxBytesLds;
+            int vgprSteps = ((waveInfo.maxNumVgpr - waveInfo.vgprBlockSize)/
+                            waveInfo.vgprBlockSize) + 1;
+            int ldsSteps = ((waveInfo.maxBytesLds - waveInfo.ldsBlockSize)/
+                           waveInfo.ldsBlockSize) + 1;
+            std::string testName = "MAX WAVE MEMORY TEST";
+
+            switch (tcase) {
+            case SAVE_AREA_TEST_WAVE_BLOCKS:
+            case SAVE_AREA_TEST_WAVE_BLOCKS_64:
+                testName = "MULTI-WAVE BLOCKS TEST";
+                numWaves = 1024;
+                numVgpr = waveInfo.vgprBlockSize * 2;
+                ldsSize = waveInfo.ldsBlockSize * 2;
+                break;
+            case SAVE_AREA_TEST_RAND_MEM_SIZE:
+            case SAVE_AREA_TEST_RAND_MEM_SIZE_64:
+                testName = "RANDOM MEM SIZE TEST";
+                numWaves = 1;
+                numVgpr = ((rand() % vgprSteps) * waveInfo.vgprBlockSize) +
+                          waveInfo.vgprBlockSize;
+                ldsSize = ((rand() % ldsSteps) * waveInfo.ldsBlockSize) +
+                          waveInfo.ldsBlockSize;
+                break;
+            case SAVE_AREA_TEST_RAND_WAVE_BLOCKS:
+            case SAVE_AREA_TEST_RAND_WAVE_BLOCKS_64:
+                testName = "RANDOM NUM WAVES TEST";
+                numWaves = 1 + (rand() % 1024);
+                numVgpr = waveInfo.vgprBlockSize * 2;
+                ldsSize = waveInfo.ldsBlockSize * 2;
+                break;
+             default:
+                break;
+             }
+
+             std::string waveString = waveInfo.isWave32 ? "32" : "64";
+             LOG() << testName << " (Wave" << waveString << ")" << std::dec << "\t => Waves: " << numWaves
+                   << "\tVGPRs per Wave: " << numVgpr
+                   << "\tLDS per Wave(Bytes): " << ldsSize << std::endl;	
+
+             ASSERT_SUCCESS_GPU(dispatch->SetNumVgprs(numVgpr, &vgprMax, &vgprBlockSize), gpuNode);
+             ASSERT_SUCCESS_GPU(dispatch->SetLdsSize(ldsSize, &ldsMax, &ldsBlockSize), gpuNode);
+             waveInfo = dispatch->GetWaveMemInfo();
+             dispatch->SetArgs(execVal, initVal);
+             dispatch->SetDim(numWaves, 1, 1);
+             dispatch->Submit(queue);
+
+             // Wait for all waves to finish wave memory initialization
+             for (int i = 0; i < numWaves; i++) {
+                 unsigned int timeoutMsec = 10000, timeIntervalMsec = 50, timeElapsedMsec = 0;
+                     while (timeElapsedMsec < timeoutMsec && !initVal[i]) {
+                         timeElapsedMsec += timeIntervalMsec;
+                         Delay(timeIntervalMsec);
+                     }
+                     ASSERT_NE_GPU(timeElapsedMsec, timeoutMsec, gpuNode);
+             }
+
+             // Infer EXEC mask from per-lane write buffer
+             uint32_t waveSize = waveInfo.isWave32 ? 32 : 64;
+             uint32_t execLo = 0, execHi = 0;
+             for (int i = 0; i < waveSize; i++) {
+                 if (execVal[i]) {
+                     if (i < 32)
+                         execLo |= 1 << i;
+                     else
+                         execHi |= 1 << i;
+                 }
+             }
+
+             // Do a bunch of save/restores
+             for (int i = 0; i < 10; i++) {
+                 EXPECT_SUCCESS_GPU(queue.Update(100, BaseQueue::DEFAULT_PRIORITY, false), gpuNode);
+                 EXPECT_SUCCESS_GPU(queue.Update(0, BaseQueue::DEFAULT_PRIORITY, false), gpuNode);
+             }
+
+             HsaQueueResource *qResource = queue.GetResource();
+             HsaQueueInfo qinfo;
+             ASSERT_SUCCESS_GPU(hsaKmtGetQueueInfo(qResource->QueueId, &qinfo), gpuNode);
+
+             const int numWaveWords = (qinfo.SaveAreaHeader->WaveStateSize/numWaves)/4;
+             const int numArgGprs = 4, numUserSgprWords = waveInfo.numUserSgpr - numArgGprs;
+
+             // Crawl the context save area to check seeded memory
+             for (int i = 0; i < numWaves; i++) {
+                 unsigned int vgprWordCount = numArgGprs * waveSize;
+                 unsigned int sgprWordCount = numArgGprs;
+                 unsigned int execWordCount =0, ldsWordCount = 0, pktLoWordCount = 0;
+                 uint32_t *addr = &qinfo.UserContextSaveArea[numWaveWords * i];
+
+                 // VGPRs
+                 unsigned int numWords = (waveInfo.numVgpr * waveSize);
+                 vgprWordCount += CheckWaveMemBlockWords(CWSR_WAVE_MEM_TYPE_VGPR, waveSize,
+                                                         &addr, numWords, vgprMask);
+
+                 // SGPRs
+                 numWords = numUserSgprWords;
+                 addr += numArgGprs;
+                 sgprWordCount += CheckWaveMemBlockWords(CWSR_WAVE_MEM_TYPE_SGPR, waveSize,
+                                                         &addr, numWords, sgprMask);
+
+                 // EXEC mask
+                 unsigned int totalFoundWords = vgprWordCount + sgprWordCount;
+                 numWords = numWaveWords - totalFoundWords - waveInfo.numBytesLds/4;
+                 execWordCount = CheckWaveMemBlockWords(CWSR_WAVE_MEM_TYPE_EXEC, waveSize,
+                                                        &addr, numWords, execLo);
+
+                 if (execHi)
+                     execWordCount += CheckWaveMemBlockWords(CWSR_WAVE_MEM_TYPE_EXEC, waveSize,
+                                                             &addr, numWords, execHi);
+
+                 // Dispatch packet ADDR LO
+                 totalFoundWords += execWordCount;
+                 numWords = numWaveWords - totalFoundWords;
+                 pktLoWordCount = CheckWaveMemBlockWords(CWSR_WAVE_MEM_TYPE_PKT_LO, waveSize,
+                                                         &addr, numWords, pktLoMask);
+
+                 // LDS
+                 if (waveInfo.numBytesLds) {
+                     numWords = numWaveWords - vgprWordCount - sgprWordCount;
+                     ldsWordCount = CheckWaveMemBlockWords(CWSR_WAVE_MEM_TYPE_LDS, waveSize,
+                                                           &addr, numWords, ldsMask);
+                 }
+
+                 EXPECT_EQ_GPU(vgprWordCount, waveInfo.numVgpr * waveSize, gpuNode);
+                 EXPECT_EQ_GPU(sgprWordCount, waveInfo.numUserSgpr, gpuNode);
+                 EXPECT_EQ_GPU(ldsWordCount, waveInfo.numBytesLds/4, gpuNode);
+                 EXPECT_EQ_GPU(execWordCount, waveInfo.isWave32 ? 1 : 2, gpuNode);
+                 EXPECT_EQ_GPU(pktLoWordCount, 1, gpuNode);
+            }
+
+            // Send requeue request
+            EXPECT_SUCCESS_GPU(queue.Update(100, BaseQueue::DEFAULT_PRIORITY, false), gpuNode);
+
+            // Trigger shader end (shader implicitly rechecks v0-v3 & s0-s3) and clean up
+            execBuf.Fill(0);
+            dispatch->Sync();
+            EXPECT_SUCCESS_GPU(queue.Destroy(), gpuNode);
+            delete dispatch;
+        }
+    } else {
+        LOG() << "Skipping test: No CWSR present for family ID 0x" << m_FamilyId << "." << std::endl;
+    }
+}
+
+TEST_F(KFDCWSRTest, SaveAreaCheck) {
+    TEST_START(TESTPROFILE_RUNALL);
+
+    ASSERT_SUCCESS(KFDTest_Launch(SaveAreaCheck));
+
+    TEST_END
+}

--- a/libhsakmt/tests/kfdtest/src/ShaderStore.cpp
+++ b/libhsakmt/tests/kfdtest/src/ShaderStore.cpp
@@ -43,7 +43,8 @@ const std::vector<const char*> ShaderList = {
     ReadMemoryIsa,
     GwsInitIsa,
     GwsAtomicIncreaseIsa,
-    CheckCuMaskIsa
+    CheckCuMaskIsa,
+    InitWaveMemoryIsa
 };
 
 /**
@@ -1188,3 +1189,108 @@ const char *WatchWriteIsa =
     WATCH_START
     "flat_store_dword v[0:1], v4"
     WATCH_END;
+
+const char *InitWaveMemoryIsa =
+    SHADER_START
+    SHADER_MACROS_U32
+    SHADER_MACROS_FLAT
+    R"(
+        .if (.amdgcn.gfx_generation_number < 12)
+            s_branch WAVE_EXIT // only support GFX 12+ testing for now
+        .endif
+        s_mov_b32		exec_lo, 0xffffffff
+        s_mov_b32		exec_hi, 0xffffffff
+        s_mov_b32		m0, 0x0
+        // Base buffer addr[laneID] in v[0:1] per laneId lane
+        v_mbcnt_lo_u32_b32	v0, -1, 0
+        v_mbcnt_hi_u32_b32 	v0, -1, v0
+        v_lshlrev_b32           v0, 2, v0
+        V_ADD_CO_U32            v0, s0, v0
+        v_mov_b32               v1, s1
+        V_ADD_CO_CI_U32         v1, v1, 0
+        // 2nd Base buffer addr[waveId] in all lanes
+        v_mov_b32		v2, ttmp9
+        v_lshlrev_b32           v2, 2, v2
+        V_ADD_CO_U32            v2, s2, v2
+        v_mov_b32               v3, s3
+        V_ADD_CO_CI_U32         v3, v3, 0
+        // Get LDS alloc size
+        s_getreg_b32		s4, hwreg(HW_REG_LDS_ALLOC)
+        s_and_b32		s4, s4, 0x7ff000
+        s_cbranch_scc0		VGPR_STORE // lds is zero
+        s_lshr_b32		s4, s4, 3 // LDS size in 512 bytes units. lshift 3 for BYTEs
+        v_mov_b32		v4, 0x12345678
+        // Init LDS words
+        LDS_STORE:
+        ds_write_addtid_b32	v4
+        s_add_u32		m0, m0, 128 // 32 lanes  * bytes
+        s_cmp_lt_u32		m0, s4
+        s_cbranch_scc1		LDS_STORE
+        // Get VGPR alloc size
+        VGPR_STORE:
+        s_getreg_b32		s4, hwreg(HW_REG_GPR_ALLOC)
+        s_and_b32		s4, s4, 0xff000
+        s_lshr_b32		s4, s4, 12
+        s_add_u32		s4, s4, 1
+        s_lshl_b32		s4, s4, 2
+        s_mov_b32		s5, 0xffff0000
+        // Init VGPR words
+        v_mbcnt_lo_u32_b32	v4, -1, 0
+        v_mbcnt_hi_u32_b32 	v4, -1, v4
+        v_or_b32		v4, v4, s5
+        v_mov_b32		v5, v4
+        v_mov_b32		v6, v4
+        v_mov_b32		v7, v4
+        s_mov_b32		m0, 0x4
+        VGPR_STORE_LOOP:
+        v_movreld_b32		v4, v4
+        v_movreld_b32		v5, v5
+        v_movreld_b32		v6, v6
+        v_movreld_b32		v7, v7
+        s_add_u32		m0, m0, 4
+        s_cmp_lt_u32		m0, s4
+        s_cbranch_scc1		VGPR_STORE_LOOP
+        // Init SGPR words
+        s_mov_b32		s4, 0x87654321
+        s_mov_b32		s5, s4
+        s_mov_b32		s6, s4
+        s_mov_b32		s7, s4
+        s_mov_b32		m0, 0x4
+        SGPR_STORE:
+        s_movreld_b32		s4, s4
+        s_movreld_b32		s5, s5
+        s_movreld_b32		s6, s6
+        s_movreld_b32		s7, s7
+        s_add_u32		m0, m0, 4
+        s_cmp_lt_u32		m0, 100	//fixed sgpr size blocks of 4
+        s_cbranch_scc1		SGPR_STORE
+        s_movreld_b32		s4, s4 // trailing 2 SGPRs (s104 & s105)
+        s_movreld_b32		s5, s5
+        s_mov_b32		exec_lo, 0x1010101
+        s_mov_b32		exec_hi, 0x2020202
+        FLAT_STORE_DWORD_NSS v[0:1], v4 scope:SCOPE_SYS // hints exec to test
+        FLAT_STORE_DWORD_NSS v[2:3], v4 scope:SCOPE_SYS // issues all waves ready to test
+        s_wait_idle
+        // Wait on test to CWSR and check save area
+        WAIT_ON_TEST:
+        s_sleep			0x10
+        FLAT_LOAD_DWORD_NSS	v4, v[0:1] scope:SCOPE_SYS
+        s_wait_idle
+        V_CMP_EQ_U32		v4, 0
+        s_cbranch_vccz		WAIT_ON_TEST
+        // retest user arg buffers saved in v0-v3
+        s_mov_b32		exec_lo, 0xffffffff
+        s_mov_b32		exec_hi, 0xffffffff
+        FLAT_LOAD_DWORD_NSS	v4, v[0:1] scope:SCOPE_SYS
+        FLAT_LOAD_DWORD_NSS	v4, v[2:3] scope:SCOPE_SYS
+        s_wait_idle
+        //retest user arg buffers saved in s0-s3
+        v_mov_b32 v0, s0
+        v_mov_b32 v1, s1
+        v_mov_b32 v2, s2
+        v_mov_b32 v3, s3
+        FLAT_LOAD_DWORD_NSS	v4, v[0:1] scope:SCOPE_SYS
+        FLAT_LOAD_DWORD_NSS	v4, v[2:3] scope:SCOPE_SYS
+        s_wait_idle
+        s_endpgm
+)";

--- a/libhsakmt/tests/kfdtest/src/ShaderStore.hpp
+++ b/libhsakmt/tests/kfdtest/src/ShaderStore.hpp
@@ -55,6 +55,7 @@ extern const char *CheckCuMaskIsa;
 
 /* KFDCWSRTest */
 extern const char *PersistentIterateIsa;
+extern const char *InitWaveMemoryIsa;
 
 /* KFDEvictTest */
 extern const char *ReadMemoryIsa;


### PR DESCRIPTION
For GFX12, test will check wave memory is correctly saved in save area.